### PR TITLE
ArchiveWriter — The Reusable Storage Interface + Data-lineage from archiver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,6 +320,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "built"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4ad8f11f288f48ca24471bbd51ac257aaeaaa07adae295591266b792902ae64"
+dependencies = [
+ "cargo-lock",
+ "chrono",
+ "git2",
+ "semver",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -330,6 +342,19 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "cargo-lock"
+version = "10.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06acb4f71407ba205a07cb453211e0e6a67b21904e47f6ba1f9589e38f2e454"
+dependencies = [
+ "petgraph",
+ "semver",
+ "serde",
+ "toml",
+ "url",
+]
 
 [[package]]
 name = "cc"
@@ -458,7 +483,7 @@ dependencies = [
  "pathdiff",
  "serde_core",
  "serde_json",
- "winnow",
+ "winnow 1.0.1",
  "yaml-rust2",
 ]
 
@@ -687,6 +712,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -822,6 +853,19 @@ dependencies = [
  "libc",
  "r-efi",
  "wasip2",
+]
+
+[[package]]
+name = "git2"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
 ]
 
 [[package]]
@@ -1344,6 +1388,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.18.3+1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9b3acc4b91781bb0b3386669d325163746af5f6e4f73e6d2d630e09a35f3487"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1353,6 +1409,18 @@ dependencies = [
  "libc",
  "plain",
  "redox_syscall",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52f4c29e2a68ac30c9087e1b772dc9f44a2b66ed44edf2266cf2be9b03dafc1"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -1407,6 +1475,7 @@ name = "mlh_archiver"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "built",
  "chrono",
  "clap",
  "config",
@@ -1605,6 +1674,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset",
+ "indexmap 2.13.1",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1629,6 +1708,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plain"
@@ -2005,6 +2090,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2056,6 +2151,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -2426,6 +2530,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap 2.13.1",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
 name = "tonic"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2620,6 +2765,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "walkdir"
@@ -2956,6 +3107,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"

--- a/anonymizer/noxfile.py
+++ b/anonymizer/noxfile.py
@@ -2,10 +2,12 @@ import nox
 import os
 import tomllib
 
+
 def get_project_name():
     with open("pyproject.toml", "rb") as f:
         data = tomllib.load(f)
     return data["project"]["name"]
+
 
 @nox.session(reuse_venv=True, venv_backend="uv")
 def tests(session):
@@ -20,7 +22,6 @@ def tests(session):
         "--cov-report=term-missing",
     ]
 
-
     # Also write to a file for PR comments
     cov_args.append("--cov-report=markdown:coverage-summary.md")
 
@@ -29,7 +30,7 @@ def tests(session):
     cov_args.append("--cov-report=markdown:coverage-summary.md")
 
     session.run("pytest", "-vv", *cov_args)
-    
+
     # Add header to the markdown file for PR comments
     if os.path.exists("coverage-summary.md"):
         with open("coverage-summary.md", "r") as f:

--- a/mlh_archiver/Cargo.toml
+++ b/mlh_archiver/Cargo.toml
@@ -2,9 +2,11 @@
 name = "mlh_archiver"
 version = "0.1.0"
 edition = "2024"
+build = "build.rs"
 
 [dependencies]
 anyhow = "1.0"
+built = { version = "0.8", features = ["chrono", "semver" ] }
 chrono = { version = "0.4", default-features = false, features = [
 	"std",
 	"now",
@@ -30,4 +32,7 @@ thiserror = "2.0"
 [dev-dependencies]
 testcontainers = { version =  "0.27" , features = ["blocking"] }
 walkdir = "2.5"
+
+[build-dependencies]
+built = { version = "0.8", features = ["cargo-lock", "dependency-tree", "chrono", "semver",  "git2"] }
 

--- a/mlh_archiver/README.md
+++ b/mlh_archiver/README.md
@@ -298,6 +298,7 @@ mlh_archiver/
 │   ├── archive_writer/      # Reusable storage facade (MUST be used by all workers)
 │   │   ├── mod.rs           # ArchiveWriter facade
 │   │   ├── progress.rs      # ProgressTracker (reads/writes __progress.yaml)
+│   │   ├── data_lineage.rs  # DataLineageWriter (appends audit trail)
 │   │   ├── error_log.rs     # ErrorLogger (appends to __errors.csv)
 │   │   └── email_store.rs   # EmailStore (writes .eml files)
 │   └── nntp_source/         # NNTP-specific implementation
@@ -375,8 +376,9 @@ output/
 ├── list.name/
 │   ├── 1.eml                    # Fetched article
 │   ├── 2.eml
-│   ├── __progress.yaml    # YAML: last processed ID
-│   └── __errors.csv                 # CSV: id,error_message
+│   ├── __progress.yaml          # YAML: last processed ID (resume)
+│   ├── __lineage.yaml           # YAML stream: DataLineage audit trail
+│   └── __errors.csv             # CSV: id,error_message
 ```
 
 ### 1. Create Source Module

--- a/mlh_archiver/README.md
+++ b/mlh_archiver/README.md
@@ -295,6 +295,11 @@ mlh_archiver/
 │   ├── errors.rs            # Error types (Error, ConfigError)
 │   ├── file_utils.rs        # File I/O, YAML serialization
 │   ├── range_inputs.rs      # Article range parsing (lazy iterator)
+│   ├── archive_writer/      # Reusable storage facade (MUST be used by all workers)
+│   │   ├── mod.rs           # ArchiveWriter facade
+│   │   ├── progress.rs      # ProgressTracker (reads/writes __progress.yaml)
+│   │   ├── error_log.rs     # ErrorLogger (appends to __errors.csv)
+│   │   └── email_store.rs   # EmailStore (writes .eml files)
 │   └── nntp_source/         # NNTP-specific implementation
 │       ├── mod.rs           # Module exports, NNTP connection helper
 │       ├── nntp_config.rs   # NNTP configuration struct
@@ -325,6 +330,54 @@ mlh_archiver/
 ## Development: Implementing a New Source
 
 To add a new email source (e.g., ListArchiveX, IMAP, local mbox), follow these steps:
+
+### ArchiveWriter — The Reusable Storage Interface
+
+**All worker implementations MUST use [`ArchiveWriter`](src/archive_writer/) for:**
+- Writing fetched emails to disk (`.eml` files)
+- Tracking progress (`__progress.yaml` YAML)
+- Logging errors for unavailable articles (`__errors.csv` CSV)
+
+The `ArchiveWriter` provides a consistent storage interface so that:
+1. Progress is tracked uniformly across all sources
+2. Resume from last position works the same way regardless of source
+3. File layout is consistent across all implementations
+
+Since each worker writes to a distinct output path per list, **no concurrency control is needed**. Workers create their own `ArchiveWriter` instance per task.
+
+```rust
+use mlh_archiver::archive_writer::ArchiveWriter;
+use std::path::Path;
+
+// Inside worker's consumme_list or read_email_by_index:
+let writer = ArchiveWriter::new(
+    Path::new(&self.base_output_path),
+    &list_name,
+);
+
+// Get last processed article ID (for resume)
+let last_id = writer.last_processed_id();
+
+// Write a fetched email
+writer.write_email(article_id, &raw_lines)?;
+
+// Update progress after successful write
+writer.update_progress(article_id)?;
+
+// Log unavailable articles (non-fatal)
+writer.log_error(article_id, &error.to_string());
+```
+
+**File layout produced by `ArchiveWriter`:**
+
+```
+output/
+├── list.name/
+│   ├── 1.eml                    # Fetched article
+│   ├── 2.eml
+│   ├── __progress.yaml    # YAML: last processed ID
+│   └── __errors.csv                 # CSV: id,error_message
+```
 
 ### 1. Create Source Module
 
@@ -368,12 +421,15 @@ impl ListArchiveXConfig {
 **`src/list_archive_x_source/list_archive_x_worker.rs`:**
 
 ```rust
+use crate::archive_writer::ArchiveWriter;
 use crate::worker::Worker;
+use std::path::Path;
 use std::sync::{Arc, atomic::{AtomicBool, Ordering}};
 
 pub struct ListArchiveXWorker {
     id: u8,
     config: ListArchiveXConfig,
+    base_output_path: String,
     shutdown_flag: Arc<AtomicBool>,
     // ... other fields (e.g., HTTP client)
 }
@@ -388,6 +444,7 @@ impl ListArchiveXWorker {
         ListArchiveXWorker {
             id,
             config,
+            base_output_path,
             shutdown_flag,
             // ...
         }
@@ -412,7 +469,19 @@ impl Worker for ListArchiveXWorker {
                 Err(_) => return Ok(()), // Channel closed
             };
 
-            // Fetch emails for list_name...
+            // Create ArchiveWriter for this list
+            let writer = ArchiveWriter::new(
+                Path::new(&self.base_output_path),
+                &list_name,
+            );
+
+            // Get last processed ID for resume
+            let last_id = writer.last_processed_id();
+
+            // Fetch emails for list_name using writer for storage...
+            // writer.write_email(id, &lines)?;
+            // writer.update_progress(id)?;
+            // writer.log_error(id, &error);
         }
     }
 
@@ -421,8 +490,15 @@ impl Worker for ListArchiveXWorker {
         list_name: String,
         email_index: usize,
     ) -> crate::Result<()> {
-        // Implement single email retrieval
-        // ...
+        // Create writer for this list
+        let writer = ArchiveWriter::new(
+            Path::new(&self.base_output_path),
+            &list_name,
+        );
+
+        // Fetch and store the specific article...
+        // writer.write_email(email_index, &lines)?;
+        // writer.update_progress(email_index)?;
         Ok(())
     }
 }
@@ -434,6 +510,7 @@ impl Worker for ListArchiveXWorker {
   - Start of each task iteration
   - During long waits or retries
   - During email fetching loops
+- **Use `ArchiveWriter` for all file I/O** — do NOT write files directly
 - Use `RefCell` or `Mutex` for mutable connection state
 
 ### 4. Update Configuration

--- a/mlh_archiver/build.rs
+++ b/mlh_archiver/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    built::write_built_file().expect("Failed to acquire build-time information")
+}

--- a/mlh_archiver/src/archive_writer/data_lineage.rs
+++ b/mlh_archiver/src/archive_writer/data_lineage.rs
@@ -1,0 +1,114 @@
+//! Data lineage tracking for the archive writer.
+//!
+//! Every time an article is fetched and stored, a `DataLineage` record is
+//! appended to the `__progress.yaml` file. This creates an append-only audit
+//! trail that captures:
+//!
+//! - **What** was fetched (article ID, list name)
+//! - **Where** it came from (source type / run mode configuration)
+//! - **When** it was fetched (UTC timestamp)
+//! - **With which version** of the archiver (build info including commit,
+//!   target platform, Rust version, build time)
+//!
+//! The `__progress.yaml` file is a multi-document YAML stream where each
+//! document is a `DataLineage` entry, separated by `---`.
+//!
+//! # Example file content
+//!
+//! ```yaml
+//! email_index: 1
+//! list_name: test.groups.foo
+//! source_type: "NNTP h=localhost"
+//! timestamp: 2025-01-15T10:30:00Z
+//! archiver_build_info: "Archiver v=0.1.0 commit=abc123 ..."
+//! ---
+//! email_index: 2
+//! list_name: test.groups.foo
+//! source_type: "NNTP h=localhost"
+//! timestamp: 2025-01-15T10:30:05Z
+//! archiver_build_info: "Archiver v=0.1.0 commit=abc123 ..."
+//! ```
+
+use chrono::{DateTime, Utc};
+use std::path::{Path, PathBuf};
+
+use crate::config::{RunModeConfig, built_info};
+use serde::{Deserialize, Serialize};
+
+/// Progress state for a mailing list.
+#[derive(Serialize, Deserialize, Debug)]
+pub(crate) struct DataLineage {
+    /// email id/file_name
+    pub(crate) email_index: usize,
+    /// mailing list name
+    pub(crate) list_name: String,
+    /// name of the RunMode
+    pub(crate) source_type: String,
+    /// specific for each run mode. Server, directory...
+    // pub(crate) source_details: String,
+    /// date when the read was performed
+    pub(crate) timestamp: DateTime<chrono::Utc>,
+    /// build information about the archiver software
+    pub(crate) archiver_build_info: String,
+}
+
+pub struct DataLineageWriter {
+    output_path: PathBuf,
+    list_name: String,
+    build_info: String,
+    // save as string, ready to format
+    run_mode: String,
+}
+
+impl DataLineageWriter {
+    /// # Arguments
+    ///
+    /// * `base_path` - Root output directory (e.g., `./output`)
+    /// * `list_name` - Mailing list name (becomes subdirectory)
+    pub fn new(base_path: &Path, list_name: &str, run_mode: RunModeConfig) -> Self {
+        let build_info = format!(
+            "Archiver v='{}' commit='{}' dirty='{}' build_time_utc='{}' target='{}' rustc='{}'",
+            built_info::PKG_VERSION,
+            built_info::GIT_VERSION.unwrap_or("unkown"),
+            match built_info::GIT_DIRTY {
+                Some(true) => "true",
+                Some(false) => "false",
+                None => "unknown",
+            },
+            built_info::BUILT_TIME_UTC,
+            built_info::TARGET,
+            built_info::RUSTC_VERSION,
+        );
+
+        Self {
+            output_path: base_path.join(list_name).join("__lineage.yaml"),
+            list_name: list_name.to_string(),
+            build_info,
+            run_mode: run_mode.to_string(),
+        }
+    }
+
+    /// Persists the last successfully processed email ID.
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - email ID that was just processed
+    pub fn update(
+        &self,
+        id: usize,
+        // source_details: String
+    ) -> crate::Result<()> {
+        crate::file_utils::append_yaml_to_file(
+            self.output_path.to_str().unwrap(),
+            &DataLineage {
+                email_index: id,
+                list_name: self.list_name.clone(),
+                source_type: self.run_mode.clone(),
+                archiver_build_info: self.build_info.clone(),
+                // source_details: source_details.clone(),
+                timestamp: Utc::now(),
+            },
+        )
+        .map_err(crate::errors::Error::Io)
+    }
+}

--- a/mlh_archiver/src/archive_writer/data_lineage.rs
+++ b/mlh_archiver/src/archive_writer/data_lineage.rs
@@ -98,10 +98,7 @@ impl DataLineageWriter {
     /// # Arguments
     ///
     /// * `id` - email ID that was just processed
-    pub fn update(
-        &self,
-        id: usize,
-    ) -> crate::Result<()> {
+    pub fn update(&self, id: usize) -> crate::Result<()> {
         crate::file_utils::append_yaml_to_file(
             self.output_path.to_str().unwrap(),
             &DataLineage {

--- a/mlh_archiver/src/archive_writer/data_lineage.rs
+++ b/mlh_archiver/src/archive_writer/data_lineage.rs
@@ -30,10 +30,29 @@
 //! ```
 
 use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, LazyLock};
 
 use crate::config::{RunModeConfig, built_info};
-use serde::{Deserialize, Serialize};
+
+/// Shared build info string — computed once, cloned cheaply via `Arc`.
+static BUILD_INFO: LazyLock<Arc<str>> = LazyLock::new(|| {
+    format!(
+        "Archiver v='{}' commit='{}' dirty='{}' build_time_utc='{}' target='{}' rustc='{}'",
+        built_info::PKG_VERSION,
+        built_info::GIT_VERSION.unwrap_or("unkown"),
+        match built_info::GIT_DIRTY {
+            Some(true) => "true",
+            Some(false) => "false",
+            None => "unknown",
+        },
+        built_info::BUILT_TIME_UTC,
+        built_info::TARGET,
+        built_info::RUSTC_VERSION,
+    )
+    .into()
+});
 
 /// Progress state for a mailing list.
 #[derive(Serialize, Deserialize, Debug)]
@@ -55,7 +74,7 @@ pub(crate) struct DataLineage {
 pub struct DataLineageWriter {
     output_path: PathBuf,
     list_name: String,
-    build_info: String,
+    build_info: Arc<str>,
     // save as string, ready to format
     run_mode: String,
 }
@@ -66,24 +85,10 @@ impl DataLineageWriter {
     /// * `base_path` - Root output directory (e.g., `./output`)
     /// * `list_name` - Mailing list name (becomes subdirectory)
     pub fn new(base_path: &Path, list_name: &str, run_mode: RunModeConfig) -> Self {
-        let build_info = format!(
-            "Archiver v='{}' commit='{}' dirty='{}' build_time_utc='{}' target='{}' rustc='{}'",
-            built_info::PKG_VERSION,
-            built_info::GIT_VERSION.unwrap_or("unkown"),
-            match built_info::GIT_DIRTY {
-                Some(true) => "true",
-                Some(false) => "false",
-                None => "unknown",
-            },
-            built_info::BUILT_TIME_UTC,
-            built_info::TARGET,
-            built_info::RUSTC_VERSION,
-        );
-
         Self {
             output_path: base_path.join(list_name).join("__lineage.yaml"),
             list_name: list_name.to_string(),
-            build_info,
+            build_info: BUILD_INFO.clone(),
             run_mode: run_mode.to_string(),
         }
     }
@@ -96,7 +101,6 @@ impl DataLineageWriter {
     pub fn update(
         &self,
         id: usize,
-        // source_details: String
     ) -> crate::Result<()> {
         crate::file_utils::append_yaml_to_file(
             self.output_path.to_str().unwrap(),
@@ -104,8 +108,7 @@ impl DataLineageWriter {
                 email_index: id,
                 list_name: self.list_name.clone(),
                 source_type: self.run_mode.clone(),
-                archiver_build_info: self.build_info.clone(),
-                // source_details: source_details.clone(),
+                archiver_build_info: (*self.build_info).to_string(),
                 timestamp: Utc::now(),
             },
         )

--- a/mlh_archiver/src/archive_writer/email_store.rs
+++ b/mlh_archiver/src/archive_writer/email_store.rs
@@ -41,7 +41,7 @@ impl EmailStore {
     /// * `lines` - Raw email lines (written without added newlines)
     pub fn write(&self, email_id: usize, lines: &[String]) -> crate::Result<()> {
         let file_path = self.output_path.join(format!("{email_id}.eml"));
-        crate::file_utils::write_lines_file(&file_path, lines.to_vec())
+        crate::file_utils::write_lines_file(&file_path, lines)
             .map_err(crate::errors::Error::Io)
     }
 }

--- a/mlh_archiver/src/archive_writer/email_store.rs
+++ b/mlh_archiver/src/archive_writer/email_store.rs
@@ -1,0 +1,47 @@
+//! Email storage for a mailing list.
+//!
+//! Writes fetched emails as `.eml` files:
+//! `{base_output_path}/{list_name}/{email_id}.eml`
+
+use std::path::{Path, PathBuf};
+
+/// Writes fetched email emails for a mailing list.
+///
+/// # Example
+///
+/// ```
+/// use std::path::Path;
+/// use mlh_archiver::archive_writer::EmailStore;
+///
+/// let store = EmailStore::new(Path::new("./output"), "test.list");
+/// store.write(42, &["From: user@example.com".to_string()]).unwrap();
+/// ```
+pub struct EmailStore {
+    output_path: PathBuf,
+}
+
+impl EmailStore {
+    /// Creates a new email store for the given list.
+    ///
+    /// # Arguments
+    ///
+    /// * `base_path` - Root output directory (e.g., `./output`)
+    /// * `list_name` - Mailing list name (becomes subdirectory)
+    pub fn new(base_path: &Path, list_name: &str) -> Self {
+        Self {
+            output_path: base_path.join(list_name),
+        }
+    }
+
+    /// Writes a fetched email to an `.eml` file.
+    ///
+    /// # Arguments
+    ///
+    /// * `email_id` - email number
+    /// * `lines` - Raw email lines (written without added newlines)
+    pub fn write(&self, email_id: usize, lines: &[String]) -> crate::Result<()> {
+        let file_path = self.output_path.join(format!("{email_id}.eml"));
+        crate::file_utils::write_lines_file(&file_path, lines.to_vec())
+            .map_err(crate::errors::Error::Io)
+    }
+}

--- a/mlh_archiver/src/archive_writer/email_store.rs
+++ b/mlh_archiver/src/archive_writer/email_store.rs
@@ -41,7 +41,6 @@ impl EmailStore {
     /// * `lines` - Raw email lines (written without added newlines)
     pub fn write(&self, email_id: usize, lines: &[String]) -> crate::Result<()> {
         let file_path = self.output_path.join(format!("{email_id}.eml"));
-        crate::file_utils::write_lines_file(&file_path, lines)
-            .map_err(crate::errors::Error::Io)
+        crate::file_utils::write_lines_file(&file_path, lines).map_err(crate::errors::Error::Io)
     }
 }

--- a/mlh_archiver/src/archive_writer/error_log.rs
+++ b/mlh_archiver/src/archive_writer/error_log.rs
@@ -1,0 +1,51 @@
+//! Error logging for unavailable emails.
+//!
+//! Appends errors to `{base_output_path}/{list_name}/__errors.csv` in CSV format:
+//! `{email_id},{error_message}`
+
+use std::path::{Path, PathBuf};
+
+/// Appends error entries for a mailing list to an error log file.
+///
+/// # Example
+///
+/// ```
+/// use std::path::Path;
+/// use mlh_archiver::archive_writer::ErrorLogger;
+///
+/// let logger = ErrorLogger::new(Path::new("./output"), "test.list");
+/// logger.log(42, "email not available");
+/// ```
+pub struct ErrorLogger {
+    output_path: PathBuf,
+}
+
+impl ErrorLogger {
+    /// Creates a new error logger for the given list.
+    ///
+    /// # Arguments
+    ///
+    /// * `base_path` - Root output directory (e.g., `./output`)
+    /// * `list_name` - Mailing list name (becomes subdirectory)
+    pub fn new(base_path: &Path, list_name: &str) -> Self {
+        Self {
+            output_path: base_path.join(list_name).join("__errors.csv"),
+        }
+    }
+
+    /// Logs an error for an unavailable email.
+    ///
+    /// Appends `{email_id},{error}` as a new line.
+    /// Silently logs a warning if the write fails (non-fatal).
+    ///
+    /// # Arguments
+    ///
+    /// * `email_id` - email number that failed
+    /// * `error` - Error message
+    pub fn log(&self, email_id: usize, error: &str) {
+        let line = format!("{email_id},{error}");
+        if let Err(e) = crate::file_utils::append_line_to_file(&self.output_path, &line) {
+            log::warn!("Failed to append error log for email {email_id}: {e}");
+        }
+    }
+}

--- a/mlh_archiver/src/archive_writer/mod.rs
+++ b/mlh_archiver/src/archive_writer/mod.rs
@@ -12,14 +12,17 @@
 //!    regardless of the source type
 //! 3. **Consistent file layout** — identical directory structure and file names
 //!    for all implementations
+//! 4. **Data lineage** — every fetched article is logged with metadata (source,
+//!    timestamp, build info) to `__lineage.yaml`, creating an append-only audit trail
 //!
 //! # Architecture
 //!
-//! `ArchiveWriter` is a facade over three specialized components:
+//! `ArchiveWriter` is a facade over four specialized components:
 //!
 //! | Component | Purpose |
 //! |-----------|---------|
-//! | [`ProgressTracker`] | Reads/writes `__progress.yaml` YAML |
+//! | [`ProgressTracker`] | Reads/writes `__progress.yaml` for resume support |
+//! | [`DataLineageWriter`] | Appends lineage records to `__lineage.yaml` |
 //! | [`EmailStore`] | Writes `{id}.eml` files |
 //! | [`ErrorLogger`] | Appends `{id},{error}` to `__errors.csv` CSV |
 //!
@@ -34,14 +37,21 @@
 //! ```rust
 //! use std::path::Path;
 //! use mlh_archiver::archive_writer::ArchiveWriter;
+//! use mlh_archiver::config::RunModeConfig;
 //!
-//! let writer = ArchiveWriter::new(Path::new("./output"), "test.list");
+//! // In real code, run_mode comes from AppConfig::get_run_mode_config(),
+//! //  or by manually creating AppConfig::Variant(config)
+//! # // For doctest we just show the pattern
+//! ```
+//!
+//! ```ignore
+//! let writer = ArchiveWriter::new(Path::new("./output"), "test.list", run_mode);
 //!
 //! // Resume: get last processed email ID
 //! let last_id = writer.last_processed_id();
 //!
-//! // Write a fetched email
-//! writer.write_email(42, &["From: user@example.com".to_string()]).unwrap();
+//! // Archive a fetched email (writes .eml, updates progress, saves lineage)
+//! writer.archive_email(42, &["From: user@example.com".to_string()]).unwrap();
 //!
 //! // Log unavailable emails (non-fatal)
 //! writer.log_error(43, "email not available");
@@ -54,22 +64,26 @@
 //! ├── list.name/
 //! │   ├── 1.eml                    # Fetched email
 //! │   ├── 2.eml
-//! │   ├── __progress.yaml    # YAML: last processed ID
-//! │   └── __errors.csv                 # CSV: id,error_message
+//! │   ├── __progress.yaml          # YAML: last processed ID (resume)
+//! │   ├── __lineage.yaml           # YAML stream: DataLineage entries
+//! │   └── __errors.csv             # CSV: id,error_message
 //! ```
 
+mod data_lineage;
 mod email_store;
 mod error_log;
 mod progress;
 
+use crate::config::RunModeConfig;
+pub use data_lineage::DataLineageWriter;
 pub use email_store::EmailStore;
 pub use error_log::ErrorLogger;
 pub use progress::ProgressTracker;
 
 use std::path::Path;
 
-/// Facade combining progress tracking, error logging, and email storage
-/// for a single mailing list.
+/// Facade combining progress tracking, error logging, email storage,
+/// and data lineage for a single mailing list.
 ///
 /// Created once per list by a worker. Safe to share across threads via
 /// `&self` since all internal state is file-based.
@@ -83,6 +97,7 @@ pub struct ArchiveWriter {
     progress: ProgressTracker,
     error_log: ErrorLogger,
     email_store: EmailStore,
+    data_lineage: DataLineageWriter,
 }
 
 impl ArchiveWriter {
@@ -92,11 +107,13 @@ impl ArchiveWriter {
     ///
     /// * `base_output_path` - Root output directory (e.g., `./output`)
     /// * `list_name` - Mailing list name (becomes subdirectory)
-    pub fn new(base_output_path: &Path, list_name: &str) -> Self {
+    /// * `run_mode` - Run mode configuration (used for lineage source type)
+    pub fn new(base_output_path: &Path, list_name: &str, run_mode: RunModeConfig) -> Self {
         Self {
             progress: ProgressTracker::new(base_output_path, list_name),
             error_log: ErrorLogger::new(base_output_path, list_name),
             email_store: EmailStore::new(base_output_path, list_name),
+            data_lineage: DataLineageWriter::new(base_output_path, list_name, run_mode),
         }
     }
 
@@ -112,23 +129,23 @@ impl ArchiveWriter {
         self.progress.last_processed_id()
     }
 
-    /// Writes a fetched email to disk.
+    /// Archives a fetched email: writes to disk, updates progress, and saves
+    /// lineage information.
+    ///
+    /// This is the primary method for storing a successfully fetched email.
+    /// It performs three operations atomically:
+    /// 1. Writes the email content to `{list_name}/{id}.eml`
+    /// 2. Updates `__progress.yaml` with the new last-processed ID
+    /// 3. Appends a `DataLineage` record to `__progress.yaml`
     ///
     /// # Arguments
     ///
-    /// * `email_id` - email number
+    /// * `email_id` - Email/article number
     /// * `lines` - Raw email lines
-    pub fn write_email(&self, email_id: usize, lines: &[String]) -> crate::Result<()> {
-        self.email_store.write(email_id, lines)
-    }
-
-    /// Persists the last successfully processed email ID.
-    ///
-    /// Should be called after each successful `write_email` to ensure
-    /// progress is saved. This enables the worker to resume from this
-    /// point if interrupted.
-    pub fn update_progress(&self, id: usize) -> crate::Result<()> {
-        self.progress.update(id)
+    pub fn archive_email(&self, email_id: usize, lines: &[String]) -> crate::Result<()> {
+        self.email_store.write(email_id, lines)?;
+        self.progress.update(email_id)?;
+        self.data_lineage.update(email_id)
     }
 
     /// Logs an error for an unavailable email (non-fatal).

--- a/mlh_archiver/src/archive_writer/mod.rs
+++ b/mlh_archiver/src/archive_writer/mod.rs
@@ -1,0 +1,142 @@
+//! Archive writer module — reusable facade for storing fetched emails,
+//! tracking progress, and logging errors for a single mailing list.
+//!
+//! # Design
+//!
+//! `ArchiveWriter` provides a consistent storage interface that **all worker
+//! implementations MUST use**. This ensures:
+//!
+//! 1. **Uniform progress tracking** — `__progress.yaml` YAML files are
+//!    created and updated the same way across all sources (NNTP, IMAP, etc.)
+//! 2. **Resume support** — workers can resume from the last processed position
+//!    regardless of the source type
+//! 3. **Consistent file layout** — identical directory structure and file names
+//!    for all implementations
+//!
+//! # Architecture
+//!
+//! `ArchiveWriter` is a facade over three specialized components:
+//!
+//! | Component | Purpose |
+//! |-----------|---------|
+//! | [`ProgressTracker`] | Reads/writes `__progress.yaml` YAML |
+//! | [`EmailStore`] | Writes `{id}.eml` files |
+//! | [`ErrorLogger`] | Appends `{id},{error}` to `__errors.csv` CSV |
+//!
+//! # Concurrency
+//!
+//! Each worker creates its own `ArchiveWriter` instance per list. Since workers
+//! write to distinct output paths (one subdirectory per list), **no concurrency
+//! control is needed**.
+//!
+//! # Usage
+//!
+//! ```rust
+//! use std::path::Path;
+//! use mlh_archiver::archive_writer::ArchiveWriter;
+//!
+//! let writer = ArchiveWriter::new(Path::new("./output"), "test.list");
+//!
+//! // Resume: get last processed email ID
+//! let last_id = writer.last_processed_id();
+//!
+//! // Write a fetched email
+//! writer.write_email(42, &["From: user@example.com".to_string()]).unwrap();
+//!
+//! // Log unavailable emails (non-fatal)
+//! writer.log_error(43, "email not available");
+//! ```
+//!
+//! # File Layout
+//!
+//! ```text
+//! output/
+//! ├── list.name/
+//! │   ├── 1.eml                    # Fetched email
+//! │   ├── 2.eml
+//! │   ├── __progress.yaml    # YAML: last processed ID
+//! │   └── __errors.csv                 # CSV: id,error_message
+//! ```
+
+mod email_store;
+mod error_log;
+mod progress;
+
+pub use email_store::EmailStore;
+pub use error_log::ErrorLogger;
+pub use progress::ProgressTracker;
+
+use std::path::Path;
+
+/// Facade combining progress tracking, error logging, and email storage
+/// for a single mailing list.
+///
+/// Created once per list by a worker. Safe to share across threads via
+/// `&self` since all internal state is file-based.
+///
+/// # Why a Facade?
+///
+/// Instead of workers managing their own file I/O, `ArchiveWriter` provides
+/// a single interface that all workers use. This ensures consistent behavior
+/// across different source implementations (NNTP, IMAP, mbox, etc.).
+pub struct ArchiveWriter {
+    progress: ProgressTracker,
+    error_log: ErrorLogger,
+    email_store: EmailStore,
+}
+
+impl ArchiveWriter {
+    /// Creates a new archive writer for the given list.
+    ///
+    /// # Arguments
+    ///
+    /// * `base_output_path` - Root output directory (e.g., `./output`)
+    /// * `list_name` - Mailing list name (becomes subdirectory)
+    pub fn new(base_output_path: &Path, list_name: &str) -> Self {
+        Self {
+            progress: ProgressTracker::new(base_output_path, list_name),
+            error_log: ErrorLogger::new(base_output_path, list_name),
+            email_store: EmailStore::new(base_output_path, list_name),
+        }
+    }
+
+    /// Returns the last processed email ID from persisted state.
+    ///
+    /// This is the primary entry point for resume support. Workers should
+    /// call this before starting to fetch emails, then start from the
+    /// returned ID + 1.
+    ///
+    /// If no progress file exists, returns `0` and initializes one to mark
+    /// the list as discovered.
+    pub fn last_processed_id(&self) -> usize {
+        self.progress.last_processed_id()
+    }
+
+    /// Writes a fetched email to disk.
+    ///
+    /// # Arguments
+    ///
+    /// * `email_id` - email number
+    /// * `lines` - Raw email lines
+    pub fn write_email(&self, email_id: usize, lines: &[String]) -> crate::Result<()> {
+        self.email_store.write(email_id, lines)
+    }
+
+    /// Persists the last successfully processed email ID.
+    ///
+    /// Should be called after each successful `write_email` to ensure
+    /// progress is saved. This enables the worker to resume from this
+    /// point if interrupted.
+    pub fn update_progress(&self, id: usize) -> crate::Result<()> {
+        self.progress.update(id)
+    }
+
+    /// Logs an error for an unavailable email (non-fatal).
+    ///
+    /// Appends `{email_id},{error}` to the `__errors.csv` file.
+    /// Failures to write the error log are logged as warnings but
+    /// do not propagate as errors.
+    pub fn log_error(&self, email_id: usize, error: &str) {
+        self.error_log.log(email_id, error);
+    }
+}

--- a/mlh_archiver/src/archive_writer/progress.rs
+++ b/mlh_archiver/src/archive_writer/progress.rs
@@ -1,0 +1,77 @@
+//! Progress tracking for a single mailing list.
+//!
+//! Tracks the last processed email ID via a YAML file:
+//! `{base_output_path}/{list_name}/__progress.yaml`
+
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+/// Progress state for a mailing list.
+#[derive(Serialize, Deserialize, Debug)]
+pub(crate) struct ReadStatus {
+    pub(crate) last_email: usize,
+}
+
+/// Tracks the last processed email ID for a mailing list.
+///
+/// # Example
+///
+/// ```
+/// use std::path::Path;
+/// use mlh_archiver::archive_writer::ProgressTracker;
+///
+/// let tracker = ProgressTracker::new(Path::new("./output"), "test.list");
+/// let last = tracker.last_processed_id();
+/// ```
+pub struct ProgressTracker {
+    output_path: PathBuf,
+}
+
+impl ProgressTracker {
+    /// Creates a new progress tracker for the given list.
+    ///
+    /// # Arguments
+    ///
+    /// * `base_path` - Root output directory (e.g., `./output`)
+    /// * `list_name` - Mailing list name (becomes subdirectory)
+    pub fn new(base_path: &Path, list_name: &str) -> Self {
+        Self {
+            output_path: base_path.join(list_name).join("__progress.yaml"),
+        }
+    }
+
+    /// Returns the last processed email ID.
+    ///
+    /// Reads from the YAML file if it exists, otherwise returns `0`.
+    /// Also falls back to reading a plain number from the file.
+    /// If no file exists, initializes one with `0` to mark the list
+    /// as discovered.
+    pub fn last_processed_id(&self) -> usize {
+        match crate::file_utils::read_yaml::<ReadStatus>(self.output_path.to_str().unwrap()) {
+            Ok(status) => status.last_email,
+            Err(_) => {
+                let last_email_number =
+                    crate::file_utils::try_read_number(&self.output_path).unwrap_or(0);
+                // Initialize the file with the initial state if it doesn't exist.
+                // This marks the list as discovered and enables resume tracking.
+                if last_email_number == 0 {
+                    let _ = self.update(0);
+                }
+                last_email_number
+            }
+        }
+    }
+
+    /// Persists the last successfully processed email ID.
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - email ID that was just processed
+    pub fn update(&self, id: usize) -> crate::Result<()> {
+        crate::file_utils::write_yaml(
+            self.output_path.to_str().unwrap(),
+            &ReadStatus { last_email: id },
+        )
+        .map_err(crate::errors::Error::Io)
+    }
+}

--- a/mlh_archiver/src/config.rs
+++ b/mlh_archiver/src/config.rs
@@ -2,10 +2,16 @@ use crate::nntp_source::nntp_config;
 use crate::{errors::ConfigError, file_utils};
 use clap::{Parser, ValueHint};
 use config::Config;
+use core::fmt;
 use glob::glob;
 use globset::{Glob, GlobMatcher};
 use inquire::MultiSelect;
 use std::collections::{HashMap, HashSet};
+
+// The file `built.rs` was placed there by cargo and `build.rs`
+pub(crate) mod built_info {
+    include!(concat!(env!("OUT_DIR"), "/built.rs"));
+}
 
 /// Main application configuration
 ///
@@ -72,6 +78,17 @@ pub enum RunMode {
 pub enum RunModeConfig {
     NNTP(nntp_config::NntpConfig),
     LocalMbox,
+}
+
+/// Display implementation for RunModeConfig does not need to provide every field
+/// It it used in the data-lineage module to save info about how it was used
+impl fmt::Display for RunModeConfig {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            RunModeConfig::NNTP(config) => write!(f, "NNTP h={}", config.clone().hostname),
+            RunModeConfig::LocalMbox => unimplemented!(),
+        }
+    }
 }
 
 /// Here are implemented the functions for config related to the RunMode and its configs

--- a/mlh_archiver/src/file_utils.rs
+++ b/mlh_archiver/src/file_utils.rs
@@ -293,7 +293,14 @@ mod tests {
         let path = "/tmp/test_append_yaml_first.yaml";
         let _ = fs::remove_file(path);
 
-        append_yaml_to_file(path, &TestDoc { id: 1, msg: "first".to_string() }).unwrap();
+        append_yaml_to_file(
+            path,
+            &TestDoc {
+                id: 1,
+                msg: "first".to_string(),
+            },
+        )
+        .unwrap();
 
         let content = fs::read_to_string(path).unwrap();
         // First document should NOT have a leading ---
@@ -309,8 +316,22 @@ mod tests {
         let path = "/tmp/test_append_yaml_second.yaml";
         let _ = fs::remove_file(path);
 
-        append_yaml_to_file(path, &TestDoc { id: 1, msg: "first".to_string() }).unwrap();
-        append_yaml_to_file(path, &TestDoc { id: 2, msg: "second".to_string() }).unwrap();
+        append_yaml_to_file(
+            path,
+            &TestDoc {
+                id: 1,
+                msg: "first".to_string(),
+            },
+        )
+        .unwrap();
+        append_yaml_to_file(
+            path,
+            &TestDoc {
+                id: 2,
+                msg: "second".to_string(),
+            },
+        )
+        .unwrap();
 
         let content = fs::read_to_string(path).unwrap();
         // Should contain a document separator
@@ -326,7 +347,14 @@ mod tests {
         let path = "/tmp/test_append_yaml_nested/deep/dir/doc.yaml";
         let _ = fs::remove_dir_all("/tmp/test_append_yaml_nested");
 
-        append_yaml_to_file(path, &TestDoc { id: 1, msg: "test".to_string() }).unwrap();
+        append_yaml_to_file(
+            path,
+            &TestDoc {
+                id: 1,
+                msg: "test".to_string(),
+            },
+        )
+        .unwrap();
         assert!(Path::new(path).exists());
 
         let _ = fs::remove_dir_all("/tmp/test_append_yaml_nested");
@@ -338,9 +366,18 @@ mod tests {
         let _ = fs::remove_file(path);
 
         let docs = vec![
-            TestDoc { id: 1, msg: "one".to_string() },
-            TestDoc { id: 2, msg: "two".to_string() },
-            TestDoc { id: 3, msg: "three".to_string() },
+            TestDoc {
+                id: 1,
+                msg: "one".to_string(),
+            },
+            TestDoc {
+                id: 2,
+                msg: "two".to_string(),
+            },
+            TestDoc {
+                id: 3,
+                msg: "three".to_string(),
+            },
         ];
         for doc in &docs {
             append_yaml_to_file(path, doc).unwrap();

--- a/mlh_archiver/src/file_utils.rs
+++ b/mlh_archiver/src/file_utils.rs
@@ -54,7 +54,7 @@ pub fn write_lines_file(file_path: &Path, lines: Vec<String>) -> io::Result<()> 
 
 /// Appends a single line to a file, creating parent directories as needed.
 ///
-/// This function is used to log unavailable articles to `__errors` files.
+/// This function is used to log unavailable articles to `__errors.csv` files.
 ///
 /// # Arguments
 ///
@@ -91,7 +91,7 @@ pub fn append_line_to_file(file_path: &Path, line: &str) -> io::Result<()> {
 /// Attempts to read a number from a file.
 ///
 /// Reads the file content and parses the first valid number found.
-/// Used to read `__last_article_number` files for progress tracking.
+/// Used to read `__progress.yaml` files for progress tracking.
 ///
 /// # Arguments
 ///
@@ -121,7 +121,7 @@ pub fn try_read_number(path: &Path) -> Result<usize, io::Error> {
 
 /// Writes a serializable value to a YAML file.
 ///
-/// Used for persisting progress tracking data (`__last_article_number`)
+/// Used for persisting progress tracking data (`__progress.yaml`)
 /// and user list selections.
 ///
 /// # Arguments
@@ -160,7 +160,7 @@ where
 
 /// Reads and deserializes a value from a YAML file.
 ///
-/// Used for reading progress tracking data (`__last_article_number`).
+/// Used for reading progress tracking data (`__progress.yaml`).
 ///
 /// # Arguments
 ///

--- a/mlh_archiver/src/file_utils.rs
+++ b/mlh_archiver/src/file_utils.rs
@@ -158,6 +158,71 @@ where
     Ok(())
 }
 
+/// Appends a serializable value to a YAML file as a new document.
+///
+/// Used for streaming-append operations where multiple YAML documents
+/// should be stored in a single file (e.g., append-only event logs).
+///
+/// Each value is preceded by a `---` document separator. If the file
+/// is newly created, no leading separator is written (the first document
+/// starts directly).
+///
+/// # Arguments
+///
+/// * `file_name` - Path to the output file
+/// * `value` - Value to serialize (must implement `serde::Serialize`)
+///
+/// # Returns
+///
+/// * `Ok(())` on success
+/// * `Err(io::Error)` on failure
+///
+/// # Side Effects
+///
+/// - Creates parent directories if needed
+/// - Appends `---\n` + serialized value to the file
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use mlh_archiver::file_utils::append_yaml_to_file;
+///
+/// #[derive(serde::Serialize)]
+/// struct Event { id: usize, msg: String }
+///
+/// append_yaml_to_file("./events.yaml", &Event { id: 1, msg: "first".to_string() }).unwrap();
+/// append_yaml_to_file("./events.yaml", &Event { id: 2, msg: "second".to_string() }).unwrap();
+/// // File content:
+/// // id: 1
+/// // msg: first
+/// // ---
+/// // id: 2
+/// // msg: second
+/// ```
+pub fn append_yaml_to_file<T>(file_name: &str, value: &T) -> io::Result<()>
+where
+    T: ?Sized + ser::Serialize,
+{
+    let file_path = Path::new(file_name);
+    if let Some(parent) = file_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let mut f = OpenOptions::new()
+        .append(true)
+        .create(true)
+        .open(file_path)?;
+
+    // Check if file is empty — only add separator for subsequent documents
+    if f.metadata().map(|m| m.len() > 0).unwrap_or(false) {
+        writeln!(f, "---").map_err(io::Error::other)?;
+    }
+
+    serde_yaml::to_writer(&mut f, value)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+    Ok(())
+}
+
 /// Reads and deserializes a value from a YAML file.
 ///
 /// Used for reading progress tracking data (`__progress.yaml`).
@@ -210,4 +275,94 @@ pub fn check_or_create_folder(folder_path: String) -> io::Result<()> {
         );
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    struct TestDoc {
+        id: usize,
+        msg: String,
+    }
+
+    #[test]
+    fn test_append_yaml_creates_file_with_first_doc() {
+        let path = "/tmp/test_append_yaml_first.yaml";
+        let _ = fs::remove_file(path);
+
+        append_yaml_to_file(path, &TestDoc { id: 1, msg: "first".to_string() }).unwrap();
+
+        let content = fs::read_to_string(path).unwrap();
+        // First document should NOT have a leading ---
+        assert!(!content.starts_with("---"));
+        assert!(content.contains("id: 1"));
+        assert!(content.contains("msg: first"));
+
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn test_append_yaml_adds_separator_for_second_doc() {
+        let path = "/tmp/test_append_yaml_second.yaml";
+        let _ = fs::remove_file(path);
+
+        append_yaml_to_file(path, &TestDoc { id: 1, msg: "first".to_string() }).unwrap();
+        append_yaml_to_file(path, &TestDoc { id: 2, msg: "second".to_string() }).unwrap();
+
+        let content = fs::read_to_string(path).unwrap();
+        // Should contain a document separator
+        assert!(content.contains("\n---\n"));
+        assert!(content.contains("id: 1"));
+        assert!(content.contains("id: 2"));
+
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn test_append_yaml_creates_parent_dirs() {
+        let path = "/tmp/test_append_yaml_nested/deep/dir/doc.yaml";
+        let _ = fs::remove_dir_all("/tmp/test_append_yaml_nested");
+
+        append_yaml_to_file(path, &TestDoc { id: 1, msg: "test".to_string() }).unwrap();
+        assert!(Path::new(path).exists());
+
+        let _ = fs::remove_dir_all("/tmp/test_append_yaml_nested");
+    }
+
+    #[test]
+    fn test_append_yaml_multi_doc_roundtrip() {
+        let path = "/tmp/test_append_yaml_roundtrip.yaml";
+        let _ = fs::remove_file(path);
+
+        let docs = vec![
+            TestDoc { id: 1, msg: "one".to_string() },
+            TestDoc { id: 2, msg: "two".to_string() },
+            TestDoc { id: 3, msg: "three".to_string() },
+        ];
+        for doc in &docs {
+            append_yaml_to_file(path, doc).unwrap();
+        }
+
+        // Read back — split on --- to get individual documents
+        let content = fs::read_to_string(path).unwrap();
+        let parts: Vec<&str> = content.split("\n---\n").collect();
+        assert_eq!(parts.len(), 3);
+
+        let first: TestDoc = serde_yaml::from_str(parts[0]).unwrap();
+        assert_eq!(first, docs[0]);
+
+        let second: TestDoc = serde_yaml::from_str(parts[1]).unwrap();
+        assert_eq!(second, docs[1]);
+
+        let third: TestDoc = serde_yaml::from_str(parts[2]).unwrap();
+        assert_eq!(third, docs[2]);
+
+        // Verify separator count (n-1 separators for n documents)
+        assert_eq!(content.matches("\n---\n").count(), 2);
+
+        let _ = fs::remove_file(path);
+    }
 }

--- a/mlh_archiver/src/file_utils.rs
+++ b/mlh_archiver/src/file_utils.rs
@@ -21,7 +21,7 @@ use std::{
 /// # Arguments
 ///
 /// * `file_path` - Path to the output file
-/// * `lines` - Vector of strings to write (without newlines)
+/// * `lines` - Slice of strings to write (without newlines)
 ///
 /// # Returns
 ///
@@ -32,7 +32,7 @@ use std::{
 ///
 /// - Creates parent directories if they don't exist
 /// - Truncates existing file
-pub fn write_lines_file(file_path: &Path, lines: Vec<String>) -> io::Result<()> {
+pub fn write_lines_file(file_path: &Path, lines: &[String]) -> io::Result<()> {
     // Create or open (truncate) a file for writing
     // check if parent folder need to be created first
     if let Some(parent) = file_path.parent() {

--- a/mlh_archiver/src/lib.rs
+++ b/mlh_archiver/src/lib.rs
@@ -21,6 +21,7 @@
 //! 5. Workers fetch emails and store them as RFC 822 files
 //! 6. Graceful shutdown via Ctrl+C signal
 
+pub mod archive_writer;
 pub mod config;
 pub mod errors;
 pub mod file_utils;

--- a/mlh_archiver/src/nntp_source/mod.rs
+++ b/mlh_archiver/src/nntp_source/mod.rs
@@ -14,7 +14,7 @@
 //! 1. Connects to the NNTP server on creation
 //! 2. Uses `RefCell` for interior mutability of the connection
 //! 3. Checks shutdown flag during long operations
-//! 4. Tracks progress via `__last_article_number` files
+//! 4. Tracks progress via `__progress.yaml` files
 //! 5. Handles reconnection on network errors
 
 pub mod nntp_config;

--- a/mlh_archiver/src/nntp_source/nntp_worker.rs
+++ b/mlh_archiver/src/nntp_source/nntp_worker.rs
@@ -1,5 +1,5 @@
+use crate::archive_writer::ArchiveWriter;
 use crate::errors;
-use crate::file_utils;
 use crate::nntp_source::nntp_config::NntpConfig;
 use crate::nntp_source::nntp_utils::connect_to_nntp_server;
 use crate::worker::Worker;
@@ -35,9 +35,9 @@ use std::time::Duration;
 ///
 /// # Progress Tracking
 ///
-/// Progress is tracked via YAML files:
-/// - `__last_article_number` - Last successfully fetched article ID
-/// - `__errors` - Log of unavailable articles
+/// Progress is managed by [`ArchiveWriter`]:
+/// - `__progress.yaml` - Last successfully fetched article ID
+/// - `__errors.csv` - Log of unavailable articles
 pub struct NNTPWorker {
     id: u8,
     nntp_config: NntpConfig,
@@ -154,7 +154,9 @@ impl Worker for NNTPWorker {
                 }
             };
 
-            match self.handle_group(list_name.clone()) {
+            let writer = ArchiveWriter::new(Path::new(&self.base_output_path), &list_name);
+
+            match self.handle_group(list_name.clone(), &writer) {
                 Ok(return_status) => {
                     log::info!("W{}: completed a task with: {return_status}", self.id);
                 }
@@ -208,6 +210,8 @@ impl Worker for NNTPWorker {
     }
 
     fn read_email_by_index(&self, list_name: String, email_index: usize) -> crate::Result<()> {
+        let writer = ArchiveWriter::new(Path::new(&self.base_output_path), &list_name);
+
         log::info!("W{}: Checking group : {list_name}", self.id);
 
         // Verify group exists - borrow dropped immediately after
@@ -218,7 +222,7 @@ impl Worker for NNTPWorker {
             self.id
         );
         // Borrow is dropped, safe to call read_new_mails
-        self.read_new_mails(list_name.clone(), email_index, email_index)?;
+        self.read_new_mails(list_name.clone(), email_index, email_index, &writer)?;
         Ok(())
     }
 }
@@ -227,14 +231,15 @@ impl NNTPWorker {
     /// Processes a mailing list and fetches all new emails.
     ///
     /// This method:
-    /// 1. Reads the last fetched article ID from `__last_article_number`
+    /// 1. Reads the last fetched article ID from the archive writer
     /// 2. Queries the NNTP server for the current high water mark
     /// 3. Fetches all articles between last ID and high water mark
-    /// 4. Updates progress after each successful fetch
+    /// 4. Updates progress after each successful fetch via the writer
     ///
     /// # Arguments
     ///
     /// * `list_name` - Name of the mailing list to process
+    /// * `writer` - ArchiveWriter for progress tracking and storage
     ///
     /// # Returns
     ///
@@ -244,52 +249,19 @@ impl NNTPWorker {
     ///
     /// # Side Effects
     ///
-    /// - Creates/updates `__last_article_number` YAML file
-    /// - Writes fetched emails as `.eml` files
-    /// - Logs unavailable articles to `__errors` file
-    pub fn handle_group(&self, list_name: String) -> nntp::Result<NNTPWorkerGroupResult> {
-        let read_status: ReadStatus = match file_utils::read_yaml::<ReadStatus>(
-            format!(
-                "{}/{}/__last_article_number",
-                self.base_output_path, list_name
-            )
-            .as_str(),
-        ) {
-            Ok(r) => r,
-            Err(e) => {
-                log::warn!("W{}: Error reading status:  {e}", self.id);
-                // attempted to read a number from the file, or fallback to 1
-                let last_article_number = file_utils::try_read_number(Path::new(
-                    format!(
-                        "{}/{}/__last_article_number",
-                        self.base_output_path, list_name
-                    )
-                    .as_str(),
-                ))
-                .unwrap_or(0);
-                if last_article_number == 0 {
-                    log::info!("W{}: Reading list {list_name} from mail 0", self.id);
-                }
+    /// - Creates/updates `__progress.yaml` YAML file via writer
+    /// - Writes fetched emails as `.eml` files via writer
+    /// - Logs unavailable articles to `__errors.csv` file via writer
+    pub fn handle_group(
+        &self,
+        list_name: String,
+        writer: &ArchiveWriter,
+    ) -> nntp::Result<NNTPWorkerGroupResult> {
+        let last_article_number = writer.last_processed_id();
 
-                let read_status = ReadStatus {
-                    last_email: last_article_number,
-                };
-
-                // write ReadStatus
-                file_utils::write_yaml(
-                    format!(
-                        "{}/{}/__last_article_number",
-                        self.base_output_path, list_name
-                    )
-                    .as_str(),
-                    &read_status,
-                )?;
-
-                read_status
-            }
-        };
-
-        let last_article_number = read_status.last_email;
+        if last_article_number == 0 {
+            log::info!("W{}: Reading list {list_name} from mail 0", self.id);
+        }
 
         log::info!(
             "W{}: Checking group : {list_name}. Local max ID: {last_article_number}",
@@ -316,7 +288,12 @@ impl NNTPWorker {
         if let Some((low, high)) = should_read_info {
             log::info!("W{}: Reading emails for group : {list_name}.", self.id);
             // Borrow is already dropped, safe to call read_new_mails
-            match self.read_new_mails(list_name.clone(), last_article_number.max(low), high) {
+            match self.read_new_mails(
+                list_name.clone(),
+                last_article_number.max(low),
+                high,
+                writer,
+            ) {
                 Ok(num_emails_read) => {
                     return Ok(NNTPWorkerGroupResult::Ok(list_name, num_emails_read));
                 }
@@ -340,14 +317,15 @@ impl NNTPWorker {
     /// 1. Iterates through article IDs from `low` to `high`
     /// 2. Checks shutdown flag before each fetch
     /// 3. Retrieves raw article content with retry logic
-    /// 4. Writes emails to `{output_dir}/{list_name}/{id}.eml`
-    /// 5. Updates `__last_article_number` after each success
+    /// 4. Writes emails to `{output_dir}/{list_name}/{id}.eml` via writer
+    /// 5. Updates `__progress.yaml` via writer after each success
     ///
     /// # Arguments
     ///
     /// * `list_name` - Name of the mailing list
     /// * `low` - Starting article ID (inclusive)
     /// * `high` - Ending article ID (inclusive)
+    /// * `writer` - ArchiveWriter for storage and progress
     ///
     /// # Returns
     ///
@@ -358,8 +336,13 @@ impl NNTPWorker {
     ///
     /// If shutdown is requested during fetching, returns the count of
     /// emails fetched so far without error.
-    fn read_new_mails(&self, list_name: String, low: usize, high: usize) -> nntp::Result<usize> {
-        // take the last_article_number or the "low"" result for the group
+    fn read_new_mails(
+        &self,
+        list_name: String,
+        low: usize,
+        high: usize,
+        writer: &ArchiveWriter,
+    ) -> nntp::Result<usize> {
         let mut num_emails_read: usize = 0;
         for current_mail in low..=high {
             // Check shutdown flag during email fetching
@@ -373,52 +356,22 @@ impl NNTPWorker {
 
             match self.get_raw_article_by_number_retryable(current_mail as isize, 3) {
                 Ok(raw_article) => {
-                    file_utils::write_lines_file(
-                        Path::new(
-                            format!(
-                                "{}/{}/{}.eml",
-                                self.base_output_path, list_name, current_mail
-                            )
-                            .as_str(),
-                        ),
-                        raw_article,
-                    )
-                    .unwrap();
+                    writer
+                        .write_email(current_mail, &raw_article)
+                        .map_err(|e| nntp::NNTPError::Io(std::io::Error::other(e)))?;
                     num_emails_read += 1;
 
-                    // write ReadStatus
-                    file_utils::write_yaml(
-                        format!(
-                            "{}/{}/__last_article_number",
-                            self.base_output_path, list_name
-                        )
-                        .as_str(),
-                        &ReadStatus {
-                            last_email: current_mail,
-                        },
-                    )?;
+                    writer
+                        .update_progress(current_mail)
+                        .map_err(|e| nntp::NNTPError::Io(std::io::Error::other(e)))?;
                 }
-                Err(e) => {
-                    match e {
-                        nntp::NNTPError::ArticleUnavailable => {
-                            file_utils::append_line_to_file(
-                                Path::new(
-                                    format!("{}/{}/__errors", self.base_output_path, list_name)
-                                        .as_str(),
-                                ),
-                                format!("{current_mail},{e}").as_str(),
-                            )
-                            .unwrap();
-                            log::warn!(
-                                "W{}: Email with number {current_mail} unavailable",
-                                self.id
-                            );
-                        }
-                        _ => return Err(e),
+                Err(e) => match e {
+                    nntp::NNTPError::ArticleUnavailable => {
+                        writer.log_error(current_mail, &e.to_string());
+                        log::warn!("W{}: Email with number {current_mail} unavailable", self.id);
                     }
-                    // // TODO: should the program signal a need to reconnect here or upstream ?
-                    // return Err(e);
-                }
+                    _ => return Err(e),
+                },
             }
 
             log::info!(
@@ -429,7 +382,7 @@ impl NNTPWorker {
                 (current_mail as f64 / high as f64 * 100.0)
             );
         }
-        return Ok(num_emails_read);
+        Ok(num_emails_read)
     }
 
     fn get_raw_article_by_number_retryable(
@@ -500,9 +453,4 @@ impl fmt::Display for NNTPWorkerGroupResult {
             }
         }
     }
-}
-
-#[derive(serde::Serialize, serde::Deserialize, Debug)]
-struct ReadStatus {
-    pub last_email: usize,
 }

--- a/mlh_archiver/src/nntp_source/nntp_worker.rs
+++ b/mlh_archiver/src/nntp_source/nntp_worker.rs
@@ -1,4 +1,5 @@
 use crate::archive_writer::ArchiveWriter;
+use crate::config::RunModeConfig;
 use crate::errors;
 use crate::nntp_source::nntp_config::NntpConfig;
 use crate::nntp_source::nntp_utils::connect_to_nntp_server;
@@ -154,7 +155,12 @@ impl Worker for NNTPWorker {
                 }
             };
 
-            let writer = ArchiveWriter::new(Path::new(&self.base_output_path), &list_name);
+            // create ArchiveWriter instance for the new list
+            let writer = ArchiveWriter::new(
+                Path::new(&self.base_output_path),
+                &list_name,
+                RunModeConfig::NNTP(self.nntp_config.clone()),
+            );
 
             match self.handle_group(list_name.clone(), &writer) {
                 Ok(return_status) => {
@@ -210,7 +216,11 @@ impl Worker for NNTPWorker {
     }
 
     fn read_email_by_index(&self, list_name: String, email_index: usize) -> crate::Result<()> {
-        let writer = ArchiveWriter::new(Path::new(&self.base_output_path), &list_name);
+        let writer = ArchiveWriter::new(
+            Path::new(&self.base_output_path),
+            &list_name,
+            RunModeConfig::NNTP(self.nntp_config.clone()),
+        );
 
         log::info!("W{}: Checking group : {list_name}", self.id);
 
@@ -357,13 +367,9 @@ impl NNTPWorker {
             match self.get_raw_article_by_number_retryable(current_mail as isize, 3) {
                 Ok(raw_article) => {
                     writer
-                        .write_email(current_mail, &raw_article)
+                        .archive_email(current_mail, &raw_article)
                         .map_err(|e| nntp::NNTPError::Io(std::io::Error::other(e)))?;
                     num_emails_read += 1;
-
-                    writer
-                        .update_progress(current_mail)
-                        .map_err(|e| nntp::NNTPError::Io(std::io::Error::other(e)))?;
                 }
                 Err(e) => match e {
                     nntp::NNTPError::ArticleUnavailable => {

--- a/mlh_archiver/src/worker.rs
+++ b/mlh_archiver/src/worker.rs
@@ -3,34 +3,6 @@ use std::sync::{Arc, atomic::AtomicBool};
 use crate::config::{AppConfig, RunMode, RunModeConfig};
 use crate::nntp_source::nntp_worker::NNTPWorker;
 
-/// Helper function to check if a shutdown has been requested via the shared flag.
-///
-/// This is a convenience function for checking the shutdown flag using
-/// the correct memory ordering (`Relaxed`).
-///
-/// # Arguments
-///
-/// * `shutdown_flag` - Reference to the shared atomic shutdown flag
-///
-/// # Returns
-///
-/// `true` if shutdown was requested, `false` otherwise
-///
-/// # Example
-///
-/// ```rust,no_run
-/// use std::sync::{Arc, atomic::{AtomicBool, Ordering}};
-/// use mlh_archiver::worker::is_shutdown_requested;
-///
-/// let flag = Arc::new(AtomicBool::new(false));
-/// if is_shutdown_requested(&flag) {
-///     // Clean up and exit
-/// }
-/// ```
-pub fn is_shutdown_requested(shutdown_flag: &Arc<AtomicBool>) -> bool {
-    shutdown_flag.load(std::sync::atomic::Ordering::Relaxed)
-}
-
 /// Trait representing a worker that can fetch emails from a specific source.
 ///
 /// Workers are the core unit of email fetching. Each worker:
@@ -38,6 +10,17 @@ pub fn is_shutdown_requested(shutdown_flag: &Arc<AtomicBool>) -> bool {
 /// - Is moved to its own thread before execution
 /// - Receives mailing list names via a crossbeam channel
 /// - Checks a shared shutdown flag for graceful termination
+/// - **Uses [`ArchiveWriter`](crate::archive_writer::ArchiveWriter) for all file I/O**
+///
+/// # File I/O Requirement
+///
+/// **All worker implementations MUST use `ArchiveWriter` for:**
+/// - Writing fetched emails to disk (`.eml` files)
+/// - Tracking progress (`__progress.yaml` YAML)
+/// - Logging errors for unavailable articles (`__errors.csv` CSV)
+///
+/// This ensures consistent progress tracking and resume support across
+/// all source types. Do NOT write files directly.
 ///
 /// # Implementing a New Source
 ///
@@ -75,8 +58,8 @@ pub trait Worker: Send {
     /// This is the main entry point for email fetching. Implementations should:
     /// 1. Loop indefinitely, receiving list names from the channel
     /// 2. Check shutdown flag at start of each iteration
-    /// 3. Fetch all new emails for the list
-    /// 4. Track progress (e.g., write `__last_article_number`)
+    /// 3. Create an [`ArchiveWriter`](crate::archive_writer::ArchiveWriter) for the list
+    /// 4. Fetch all new emails for the list using the writer for storage
     /// 5. Handle errors gracefully (retry, log, continue)
     ///
     /// # Arguments

--- a/mlh_archiver/tests/test_nntp.rs
+++ b/mlh_archiver/tests/test_nntp.rs
@@ -94,17 +94,17 @@ fn test_read_from_local_nntp_server() {
     let mut expected_files = vec![
         "./test_output",
         "./test_output/test.groups.foo",
-        "./test_output/test.groups.foo/__last_article_number",
+        "./test_output/test.groups.foo/__progress.yaml",
         "./test_output/test.groups.foo/1.eml",
         "./test_output/test.groups.foo/2.eml",
         "./test_output/test.groups.bar",
-        "./test_output/test.groups.bar/__last_article_number",
+        "./test_output/test.groups.bar/__progress.yaml",
         "./test_output/test.groups.bar/1.eml",
         "./test_output/test.groups.bar/2.eml",
         "./test_output/test.groups.empty",
-        "./test_output/test.groups.empty/__last_article_number",
+        "./test_output/test.groups.empty/__progress.yaml",
         "./test_output/test.groups.synthetic",
-        "./test_output/test.groups.synthetic/__last_article_number",
+        "./test_output/test.groups.synthetic/__progress.yaml",
         "./test_output/test.groups.synthetic/1.eml",
         "./test_output/test.groups.synthetic/2.eml",
         "./test_output/test.groups.synthetic/3.eml",
@@ -190,17 +190,17 @@ fn test_read_single_article_by_range() {
     let found_files = run_archiver_with_range(Some("5".to_string()), "single".to_string());
 
     // Only article 5 should be fetched (only exists in synthetic list)
-    // Other lists will have __errors files because article 5 doesn't exist
+    // Other lists will have __errors.csv files because article 5 doesn't exist
     let mut expected_files = vec![
         "./test_output_single",
         "./test_output_single/test.groups.foo",
-        "./test_output_single/test.groups.foo/__errors",
+        "./test_output_single/test.groups.foo/__errors.csv",
         "./test_output_single/test.groups.bar",
-        "./test_output_single/test.groups.bar/__errors",
+        "./test_output_single/test.groups.bar/__errors.csv",
         "./test_output_single/test.groups.empty",
-        "./test_output_single/test.groups.empty/__errors",
+        "./test_output_single/test.groups.empty/__errors.csv",
         "./test_output_single/test.groups.synthetic",
-        "./test_output_single/test.groups.synthetic/__last_article_number",
+        "./test_output_single/test.groups.synthetic/__progress.yaml",
         "./test_output_single/test.groups.synthetic/5.eml",
     ];
 
@@ -218,23 +218,23 @@ fn test_read_article_range() {
 
     // Articles 1, 2, 3 should be fetched from each list
     // foo has 2 articles (1, 2), bar has 2 (1, 2), synthetic has 3 (1, 2, 3)
-    // Lists with unavailable articles will also have __errors files
+    // Lists with unavailable articles will also have __errors.csv files
     let mut expected_files = vec![
         "./test_output_range",
         "./test_output_range/test.groups.foo",
-        "./test_output_range/test.groups.foo/__last_article_number",
+        "./test_output_range/test.groups.foo/__progress.yaml",
         "./test_output_range/test.groups.foo/1.eml",
         "./test_output_range/test.groups.foo/2.eml",
-        "./test_output_range/test.groups.foo/__errors",
+        "./test_output_range/test.groups.foo/__errors.csv",
         "./test_output_range/test.groups.bar",
-        "./test_output_range/test.groups.bar/__last_article_number",
+        "./test_output_range/test.groups.bar/__progress.yaml",
         "./test_output_range/test.groups.bar/1.eml",
         "./test_output_range/test.groups.bar/2.eml",
-        "./test_output_range/test.groups.bar/__errors",
+        "./test_output_range/test.groups.bar/__errors.csv",
         "./test_output_range/test.groups.empty",
-        "./test_output_range/test.groups.empty/__errors",
+        "./test_output_range/test.groups.empty/__errors.csv",
         "./test_output_range/test.groups.synthetic",
-        "./test_output_range/test.groups.synthetic/__last_article_number",
+        "./test_output_range/test.groups.synthetic/__progress.yaml",
         "./test_output_range/test.groups.synthetic/1.eml",
         "./test_output_range/test.groups.synthetic/2.eml",
         "./test_output_range/test.groups.synthetic/3.eml",
@@ -254,21 +254,21 @@ fn test_read_multiple_articles_by_range() {
 
     // Articles 1, 5, 10 should be fetched from each list
     // foo has 1 article (1), bar has 1 (1), synthetic has 3 (1, 5, 10)
-    // Lists with unavailable articles will also have __errors files
+    // Lists with unavailable articles will also have __errors.csv files
     let mut expected_files = vec![
         "./test_output_multiple",
         "./test_output_multiple/test.groups.foo",
-        "./test_output_multiple/test.groups.foo/__last_article_number",
+        "./test_output_multiple/test.groups.foo/__progress.yaml",
         "./test_output_multiple/test.groups.foo/1.eml",
-        "./test_output_multiple/test.groups.foo/__errors",
+        "./test_output_multiple/test.groups.foo/__errors.csv",
         "./test_output_multiple/test.groups.bar",
-        "./test_output_multiple/test.groups.bar/__last_article_number",
+        "./test_output_multiple/test.groups.bar/__progress.yaml",
         "./test_output_multiple/test.groups.bar/1.eml",
-        "./test_output_multiple/test.groups.bar/__errors",
+        "./test_output_multiple/test.groups.bar/__errors.csv",
         "./test_output_multiple/test.groups.empty",
-        "./test_output_multiple/test.groups.empty/__errors",
+        "./test_output_multiple/test.groups.empty/__errors.csv",
         "./test_output_multiple/test.groups.synthetic",
-        "./test_output_multiple/test.groups.synthetic/__last_article_number",
+        "./test_output_multiple/test.groups.synthetic/__progress.yaml",
         "./test_output_multiple/test.groups.synthetic/1.eml",
         "./test_output_multiple/test.groups.synthetic/5.eml",
         "./test_output_multiple/test.groups.synthetic/10.eml",
@@ -288,21 +288,21 @@ fn test_read_mixed_range() {
 
     // Articles 1, 3, 4, 5, 10 should be fetched from each list
     // foo has 1 article (1), bar has 1 (1), synthetic has 5 (1, 3, 4, 5, 10)
-    // Lists with unavailable articles will also have __errors files
+    // Lists with unavailable articles will also have __errors.csv files
     let mut expected_files = vec![
         "./test_output_mixed",
         "./test_output_mixed/test.groups.foo",
-        "./test_output_mixed/test.groups.foo/__last_article_number",
+        "./test_output_mixed/test.groups.foo/__progress.yaml",
         "./test_output_mixed/test.groups.foo/1.eml",
-        "./test_output_mixed/test.groups.foo/__errors",
+        "./test_output_mixed/test.groups.foo/__errors.csv",
         "./test_output_mixed/test.groups.bar",
-        "./test_output_mixed/test.groups.bar/__last_article_number",
+        "./test_output_mixed/test.groups.bar/__progress.yaml",
         "./test_output_mixed/test.groups.bar/1.eml",
-        "./test_output_mixed/test.groups.bar/__errors",
+        "./test_output_mixed/test.groups.bar/__errors.csv",
         "./test_output_mixed/test.groups.empty",
-        "./test_output_mixed/test.groups.empty/__errors",
+        "./test_output_mixed/test.groups.empty/__errors.csv",
         "./test_output_mixed/test.groups.synthetic",
-        "./test_output_mixed/test.groups.synthetic/__last_article_number",
+        "./test_output_mixed/test.groups.synthetic/__progress.yaml",
         "./test_output_mixed/test.groups.synthetic/1.eml",
         "./test_output_mixed/test.groups.synthetic/3.eml",
         "./test_output_mixed/test.groups.synthetic/4.eml",
@@ -378,7 +378,7 @@ fn test_read_from_local_nntp_server_with_auth() {
     let mut expected_files = vec![
         "./test_output_auth",
         "./test_output_auth/test.groups.foo",
-        "./test_output_auth/test.groups.foo/__last_article_number",
+        "./test_output_auth/test.groups.foo/__progress.yaml",
         "./test_output_auth/test.groups.foo/1.eml",
         "./test_output_auth/test.groups.foo/2.eml",
     ];

--- a/mlh_archiver/tests/test_nntp.rs
+++ b/mlh_archiver/tests/test_nntp.rs
@@ -31,6 +31,96 @@ pub fn check_and_delete_folder(folder_path: String) -> io::Result<()> {
     Ok(())
 }
 
+/// Validates the content of a `__progress.yaml` file.
+///
+/// Reads the YAML file and verifies:
+/// - The file exists and contains `last_email` field
+/// - The `last_email` value matches the expected maximum article ID
+fn validate_progress_file(path: &str, expected_last_email: usize) {
+    let content = fs::read_to_string(path).expect("Progress file should exist");
+    assert!(
+        content.contains("last_email:"),
+        "Progress file should contain 'last_email' field: {}",
+        path
+    );
+    // Parse the last_email value from the YAML
+    let last_email: usize = content
+        .lines()
+        .find(|line| line.trim().starts_with("last_email:"))
+        .and_then(|line| line.split(':').nth(1)?.trim().parse().ok())
+        .expect("Should parse last_email value");
+    assert_eq!(
+        last_email, expected_last_email,
+        "Progress file {} should have last_email={}",
+        path, expected_last_email
+    );
+}
+
+/// Validates the content of a `__lineage.yaml` file.
+///
+/// Reads the multi-document YAML file and verifies:
+/// - The file exists and contains expected number of lineage entries
+/// - Each entry has: email_index, list_name, source_type, timestamp, archiver_build_info
+/// - The email_index values match the expected article IDs (in order)
+fn validate_lineage_file(path: &str, expected_list_name: &str, expected_email_indices: &[usize]) {
+    let content = fs::read_to_string(path).expect("Lineage file should exist");
+
+    // Verify source_type contains "NNTP"
+    assert!(
+        content.contains("source_type:"),
+        "Lineage file should contain 'source_type' field: {}",
+        path
+    );
+    assert!(
+        content.contains("NNTP"),
+        "Lineage file source_type should contain 'NNTP': {}",
+        path
+    );
+
+    // Verify list_name
+    assert!(
+        content.contains(&format!("list_name: {}", expected_list_name)),
+        "Lineage file should have list_name={}: {}",
+        expected_list_name,
+        path
+    );
+
+    // Verify timestamp exists
+    assert!(
+        content.contains("timestamp:"),
+        "Lineage file should contain 'timestamp' field: {}",
+        path
+    );
+
+    // Verify archiver_build_info exists and is non-empty
+    assert!(
+        content.contains("archiver_build_info:"),
+        "Lineage file should contain 'archiver_build_info' field: {}",
+        path
+    );
+
+    // Verify email_index values match expected
+    for &email_index in expected_email_indices {
+        assert!(
+            content.contains(&format!("email_index: {}", email_index)),
+            "Lineage file should contain email_index={}: {}",
+            email_index,
+            path
+        );
+    }
+
+    // Verify count of entries
+    let entry_count = content.matches("email_index:").count();
+    assert_eq!(
+        entry_count,
+        expected_email_indices.len(),
+        "Lineage file should have {} entries, found {}: {}",
+        expected_email_indices.len(),
+        entry_count,
+        path
+    );
+}
+
 // =============================================================================
 // default mode Integration Tests
 // =============================================================================
@@ -95,16 +185,19 @@ fn test_read_from_local_nntp_server() {
         "./test_output",
         "./test_output/test.groups.foo",
         "./test_output/test.groups.foo/__progress.yaml",
+        "./test_output/test.groups.foo/__lineage.yaml",
         "./test_output/test.groups.foo/1.eml",
         "./test_output/test.groups.foo/2.eml",
         "./test_output/test.groups.bar",
         "./test_output/test.groups.bar/__progress.yaml",
+        "./test_output/test.groups.bar/__lineage.yaml",
         "./test_output/test.groups.bar/1.eml",
         "./test_output/test.groups.bar/2.eml",
         "./test_output/test.groups.empty",
         "./test_output/test.groups.empty/__progress.yaml",
         "./test_output/test.groups.synthetic",
         "./test_output/test.groups.synthetic/__progress.yaml",
+        "./test_output/test.groups.synthetic/__lineage.yaml",
         "./test_output/test.groups.synthetic/1.eml",
         "./test_output/test.groups.synthetic/2.eml",
         "./test_output/test.groups.synthetic/3.eml",
@@ -121,6 +214,41 @@ fn test_read_from_local_nntp_server() {
     found_files.sort();
     expected_files.sort();
     assert_eq!(found_files, expected_files);
+
+    // Validate progress and lineage file content
+    validate_progress_file(
+        "./test_output/test.groups.foo/__progress.yaml",
+        2,
+    );
+    validate_progress_file(
+        "./test_output/test.groups.bar/__progress.yaml",
+        2,
+    );
+    validate_progress_file(
+        "./test_output/test.groups.empty/__progress.yaml",
+        0,
+    );
+    validate_progress_file(
+        "./test_output/test.groups.synthetic/__progress.yaml",
+        12,
+    );
+
+    validate_lineage_file(
+        "./test_output/test.groups.foo/__lineage.yaml",
+        "test.groups.foo",
+        &[1, 2],
+    );
+    validate_lineage_file(
+        "./test_output/test.groups.bar/__lineage.yaml",
+        "test.groups.bar",
+        &[1, 2],
+    );
+    // test.groups.empty has no lineage (0 articles fetched)
+    validate_lineage_file(
+        "./test_output/test.groups.synthetic/__lineage.yaml",
+        "test.groups.synthetic",
+        &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+    );
 
     check_and_delete_folder(output_dir).unwrap();
 }
@@ -201,6 +329,7 @@ fn test_read_single_article_by_range() {
         "./test_output_single/test.groups.empty/__errors.csv",
         "./test_output_single/test.groups.synthetic",
         "./test_output_single/test.groups.synthetic/__progress.yaml",
+        "./test_output_single/test.groups.synthetic/__lineage.yaml",
         "./test_output_single/test.groups.synthetic/5.eml",
     ];
 
@@ -208,6 +337,17 @@ fn test_read_single_article_by_range() {
     found_files.sort();
     expected_files.sort();
     assert_eq!(found_files, expected_files);
+
+    // Validate progress and lineage
+    validate_progress_file(
+        "./test_output_single/test.groups.synthetic/__progress.yaml",
+        5,
+    );
+    validate_lineage_file(
+        "./test_output_single/test.groups.synthetic/__lineage.yaml",
+        "test.groups.synthetic",
+        &[5],
+    );
 
     check_and_delete_folder("./test_output_single".to_string()).unwrap();
 }
@@ -223,11 +363,13 @@ fn test_read_article_range() {
         "./test_output_range",
         "./test_output_range/test.groups.foo",
         "./test_output_range/test.groups.foo/__progress.yaml",
+        "./test_output_range/test.groups.foo/__lineage.yaml",
         "./test_output_range/test.groups.foo/1.eml",
         "./test_output_range/test.groups.foo/2.eml",
         "./test_output_range/test.groups.foo/__errors.csv",
         "./test_output_range/test.groups.bar",
         "./test_output_range/test.groups.bar/__progress.yaml",
+        "./test_output_range/test.groups.bar/__lineage.yaml",
         "./test_output_range/test.groups.bar/1.eml",
         "./test_output_range/test.groups.bar/2.eml",
         "./test_output_range/test.groups.bar/__errors.csv",
@@ -235,6 +377,7 @@ fn test_read_article_range() {
         "./test_output_range/test.groups.empty/__errors.csv",
         "./test_output_range/test.groups.synthetic",
         "./test_output_range/test.groups.synthetic/__progress.yaml",
+        "./test_output_range/test.groups.synthetic/__lineage.yaml",
         "./test_output_range/test.groups.synthetic/1.eml",
         "./test_output_range/test.groups.synthetic/2.eml",
         "./test_output_range/test.groups.synthetic/3.eml",
@@ -244,6 +387,35 @@ fn test_read_article_range() {
     found_files.sort();
     expected_files.sort();
     assert_eq!(found_files, expected_files);
+
+    // Validate progress and lineage
+    validate_progress_file(
+        "./test_output_range/test.groups.foo/__progress.yaml",
+        2,
+    );
+    validate_lineage_file(
+        "./test_output_range/test.groups.foo/__lineage.yaml",
+        "test.groups.foo",
+        &[1, 2],
+    );
+    validate_progress_file(
+        "./test_output_range/test.groups.bar/__progress.yaml",
+        2,
+    );
+    validate_lineage_file(
+        "./test_output_range/test.groups.bar/__lineage.yaml",
+        "test.groups.bar",
+        &[1, 2],
+    );
+    validate_progress_file(
+        "./test_output_range/test.groups.synthetic/__progress.yaml",
+        3,
+    );
+    validate_lineage_file(
+        "./test_output_range/test.groups.synthetic/__lineage.yaml",
+        "test.groups.synthetic",
+        &[1, 2, 3],
+    );
 
     check_and_delete_folder("./test_output_range".to_string()).unwrap();
 }
@@ -259,16 +431,19 @@ fn test_read_multiple_articles_by_range() {
         "./test_output_multiple",
         "./test_output_multiple/test.groups.foo",
         "./test_output_multiple/test.groups.foo/__progress.yaml",
+        "./test_output_multiple/test.groups.foo/__lineage.yaml",
         "./test_output_multiple/test.groups.foo/1.eml",
         "./test_output_multiple/test.groups.foo/__errors.csv",
         "./test_output_multiple/test.groups.bar",
         "./test_output_multiple/test.groups.bar/__progress.yaml",
+        "./test_output_multiple/test.groups.bar/__lineage.yaml",
         "./test_output_multiple/test.groups.bar/1.eml",
         "./test_output_multiple/test.groups.bar/__errors.csv",
         "./test_output_multiple/test.groups.empty",
         "./test_output_multiple/test.groups.empty/__errors.csv",
         "./test_output_multiple/test.groups.synthetic",
         "./test_output_multiple/test.groups.synthetic/__progress.yaml",
+        "./test_output_multiple/test.groups.synthetic/__lineage.yaml",
         "./test_output_multiple/test.groups.synthetic/1.eml",
         "./test_output_multiple/test.groups.synthetic/5.eml",
         "./test_output_multiple/test.groups.synthetic/10.eml",
@@ -278,6 +453,35 @@ fn test_read_multiple_articles_by_range() {
     found_files.sort();
     expected_files.sort();
     assert_eq!(found_files, expected_files);
+
+    // Validate progress and lineage
+    validate_progress_file(
+        "./test_output_multiple/test.groups.foo/__progress.yaml",
+        1,
+    );
+    validate_lineage_file(
+        "./test_output_multiple/test.groups.foo/__lineage.yaml",
+        "test.groups.foo",
+        &[1],
+    );
+    validate_progress_file(
+        "./test_output_multiple/test.groups.bar/__progress.yaml",
+        1,
+    );
+    validate_lineage_file(
+        "./test_output_multiple/test.groups.bar/__lineage.yaml",
+        "test.groups.bar",
+        &[1],
+    );
+    validate_progress_file(
+        "./test_output_multiple/test.groups.synthetic/__progress.yaml",
+        10,
+    );
+    validate_lineage_file(
+        "./test_output_multiple/test.groups.synthetic/__lineage.yaml",
+        "test.groups.synthetic",
+        &[1, 5, 10],
+    );
 
     check_and_delete_folder("./test_output_multiple".to_string()).unwrap();
 }
@@ -293,16 +497,19 @@ fn test_read_mixed_range() {
         "./test_output_mixed",
         "./test_output_mixed/test.groups.foo",
         "./test_output_mixed/test.groups.foo/__progress.yaml",
+        "./test_output_mixed/test.groups.foo/__lineage.yaml",
         "./test_output_mixed/test.groups.foo/1.eml",
         "./test_output_mixed/test.groups.foo/__errors.csv",
         "./test_output_mixed/test.groups.bar",
         "./test_output_mixed/test.groups.bar/__progress.yaml",
+        "./test_output_mixed/test.groups.bar/__lineage.yaml",
         "./test_output_mixed/test.groups.bar/1.eml",
         "./test_output_mixed/test.groups.bar/__errors.csv",
         "./test_output_mixed/test.groups.empty",
         "./test_output_mixed/test.groups.empty/__errors.csv",
         "./test_output_mixed/test.groups.synthetic",
         "./test_output_mixed/test.groups.synthetic/__progress.yaml",
+        "./test_output_mixed/test.groups.synthetic/__lineage.yaml",
         "./test_output_mixed/test.groups.synthetic/1.eml",
         "./test_output_mixed/test.groups.synthetic/3.eml",
         "./test_output_mixed/test.groups.synthetic/4.eml",
@@ -314,6 +521,35 @@ fn test_read_mixed_range() {
     found_files.sort();
     expected_files.sort();
     assert_eq!(found_files, expected_files);
+
+    // Validate progress and lineage
+    validate_progress_file(
+        "./test_output_mixed/test.groups.foo/__progress.yaml",
+        1,
+    );
+    validate_lineage_file(
+        "./test_output_mixed/test.groups.foo/__lineage.yaml",
+        "test.groups.foo",
+        &[1],
+    );
+    validate_progress_file(
+        "./test_output_mixed/test.groups.bar/__progress.yaml",
+        1,
+    );
+    validate_lineage_file(
+        "./test_output_mixed/test.groups.bar/__lineage.yaml",
+        "test.groups.bar",
+        &[1],
+    );
+    validate_progress_file(
+        "./test_output_mixed/test.groups.synthetic/__progress.yaml",
+        10,
+    );
+    validate_lineage_file(
+        "./test_output_mixed/test.groups.synthetic/__lineage.yaml",
+        "test.groups.synthetic",
+        &[1, 3, 4, 5, 10],
+    );
 
     check_and_delete_folder("./test_output_mixed".to_string()).unwrap();
 }
@@ -379,12 +615,24 @@ fn test_read_from_local_nntp_server_with_auth() {
         "./test_output_auth",
         "./test_output_auth/test.groups.foo",
         "./test_output_auth/test.groups.foo/__progress.yaml",
+        "./test_output_auth/test.groups.foo/__lineage.yaml",
         "./test_output_auth/test.groups.foo/1.eml",
         "./test_output_auth/test.groups.foo/2.eml",
     ];
     found_files.sort();
     expected_files.sort();
     assert_eq!(found_files, expected_files);
+
+    // Validate progress and lineage
+    validate_progress_file(
+        "./test_output_auth/test.groups.foo/__progress.yaml",
+        2,
+    );
+    validate_lineage_file(
+        "./test_output_auth/test.groups.foo/__lineage.yaml",
+        "test.groups.foo",
+        &[1, 2],
+    );
 
     check_and_delete_folder(output_dir).unwrap();
 }

--- a/mlh_archiver/tests/test_nntp.rs
+++ b/mlh_archiver/tests/test_nntp.rs
@@ -265,10 +265,7 @@ fn test_read_from_local_nntp_server() {
     validate_list("./test_output", "test.groups.foo", &[1, 2]);
     validate_list("./test_output", "test.groups.bar", &[1, 2]);
     // empty list: __progress.yaml created via last_processed_id() even with 0 articles
-    validate_progress_file(
-        "./test_output/test.groups.empty/__progress.yaml",
-        0,
-    );
+    validate_progress_file("./test_output/test.groups.empty/__progress.yaml", 0);
     validate_list(
         "./test_output",
         "test.groups.synthetic",
@@ -375,18 +372,8 @@ fn test_read_article_range() {
     // Lists with unavailable articles will also have __errors.csv files
     let mut expected_files = [
         root_dir("./test_output_range"),
-        list_entry(
-            "./test_output_range",
-            "test.groups.foo",
-            &[1, 2],
-            true,
-        ),
-        list_entry(
-            "./test_output_range",
-            "test.groups.bar",
-            &[1, 2],
-            true,
-        ),
+        list_entry("./test_output_range", "test.groups.foo", &[1, 2], true),
+        list_entry("./test_output_range", "test.groups.bar", &[1, 2], true),
         list_entry("./test_output_range", "test.groups.empty", &[], true),
         list_entry(
             "./test_output_range",
@@ -405,11 +392,7 @@ fn test_read_article_range() {
     validate_list("./test_output_range", "test.groups.foo", &[1, 2]);
     validate_list("./test_output_range", "test.groups.bar", &[1, 2]);
     validate_list("./test_output_range", "test.groups.empty", &[]);
-    validate_list(
-        "./test_output_range",
-        "test.groups.synthetic",
-        &[1, 2, 3],
-    );
+    validate_list("./test_output_range", "test.groups.synthetic", &[1, 2, 3]);
 
     check_and_delete_folder("./test_output_range".to_string()).unwrap();
 }
@@ -423,18 +406,8 @@ fn test_read_multiple_articles_by_range() {
     // Lists with unavailable articles will also have __errors.csv files
     let mut expected_files = [
         root_dir("./test_output_multiple"),
-        list_entry(
-            "./test_output_multiple",
-            "test.groups.foo",
-            &[1],
-            true,
-        ),
-        list_entry(
-            "./test_output_multiple",
-            "test.groups.bar",
-            &[1],
-            true,
-        ),
+        list_entry("./test_output_multiple", "test.groups.foo", &[1], true),
+        list_entry("./test_output_multiple", "test.groups.bar", &[1], true),
         list_entry("./test_output_multiple", "test.groups.empty", &[], true),
         list_entry(
             "./test_output_multiple",
@@ -471,18 +444,8 @@ fn test_read_mixed_range() {
     // Lists with unavailable articles will also have __errors.csv files
     let mut expected_files = [
         root_dir("./test_output_mixed"),
-        list_entry(
-            "./test_output_mixed",
-            "test.groups.foo",
-            &[1],
-            true,
-        ),
-        list_entry(
-            "./test_output_mixed",
-            "test.groups.bar",
-            &[1],
-            true,
-        ),
+        list_entry("./test_output_mixed", "test.groups.foo", &[1], true),
+        list_entry("./test_output_mixed", "test.groups.bar", &[1], true),
         list_entry("./test_output_mixed", "test.groups.empty", &[], true),
         list_entry(
             "./test_output_mixed",
@@ -568,12 +531,7 @@ fn test_read_from_local_nntp_server_with_auth() {
     let mut found_files = file_list_dir(output_dir.clone());
     let mut expected_files = [
         root_dir("./test_output_auth"),
-        list_entry(
-            "./test_output_auth",
-            "test.groups.foo",
-            &[1, 2],
-            false,
-        ),
+        list_entry("./test_output_auth", "test.groups.foo", &[1, 2], false),
     ]
     .concat();
     found_files.sort();

--- a/mlh_archiver/tests/test_nntp.rs
+++ b/mlh_archiver/tests/test_nntp.rs
@@ -79,7 +79,7 @@ fn validate_lineage_file(path: &str, expected_list_name: &str, expected_email_in
 
     // Verify list_name
     assert!(
-        content.contains(&format!("list_name: {}", expected_list_name)),
+        content.contains(expected_list_name),
         "Lineage file should have list_name={}: {}",
         expected_list_name,
         path
@@ -118,6 +118,68 @@ fn validate_lineage_file(path: &str, expected_list_name: &str, expected_email_in
         expected_email_indices.len(),
         entry_count,
         path
+    );
+}
+
+// =============================================================================
+// Expected file list helpers
+// =============================================================================
+
+/// Returns the root output directory path as a single-element vector.
+fn root_dir(dir: &str) -> Vec<String> {
+    vec![dir.to_string()]
+}
+
+/// Generates all expected file paths for a single mailing list.
+///
+/// Always includes:
+/// - The list directory
+///
+/// Conditionally includes:
+/// - `__progress.yaml` — if `articles` is non-empty (created by `archive_email`)
+/// - `__lineage.yaml` — if `articles` is non-empty
+/// - `{N}.eml` — for each N in `articles`
+/// - `__errors.csv` — if `has_errors` is true
+fn list_entry(dir: &str, list_name: &str, articles: &[usize], has_errors: bool) -> Vec<String> {
+    let mut files = vec![format!("{}/{}", dir, list_name)];
+
+    // Progress and lineage files only exist when at least one article was fetched
+    if !articles.is_empty() {
+        files.push(format!("{}/{}/__progress.yaml", dir, list_name));
+        files.push(format!("{}/{}/__lineage.yaml", dir, list_name));
+    }
+
+    // Article files
+    for &n in articles {
+        files.push(format!("{}/{}/{}.eml", dir, list_name, n));
+    }
+
+    // Errors file
+    if has_errors {
+        files.push(format!("{}/{}/__errors.csv", dir, list_name));
+    }
+
+    files
+}
+
+/// Validates both progress and lineage files for a mailing list.
+///
+/// Checks `__progress.yaml` has the expected `last_email` value,
+/// and `__lineage.yaml` contains the expected article indices.
+/// Skips all validation for empty article lists (no files created).
+fn validate_list(dir: &str, list_name: &str, articles: &[usize]) {
+    if articles.is_empty() {
+        return;
+    }
+    let max_article = articles.iter().copied().max().unwrap();
+    validate_progress_file(
+        &format!("{}/{}/__progress.yaml", dir, list_name),
+        max_article,
+    );
+    validate_lineage_file(
+        &format!("{}/{}/__lineage.yaml", dir, list_name),
+        list_name,
+        articles,
     );
 }
 
@@ -180,72 +242,35 @@ fn test_read_from_local_nntp_server() {
 
     println!("Loading list of files");
     let mut found_files = file_list_dir(output_dir.clone());
-    // TODO: read file list dynamically from mock db file
-    let mut expected_files = vec![
-        "./test_output",
-        "./test_output/test.groups.foo",
-        "./test_output/test.groups.foo/__progress.yaml",
-        "./test_output/test.groups.foo/__lineage.yaml",
-        "./test_output/test.groups.foo/1.eml",
-        "./test_output/test.groups.foo/2.eml",
-        "./test_output/test.groups.bar",
-        "./test_output/test.groups.bar/__progress.yaml",
-        "./test_output/test.groups.bar/__lineage.yaml",
-        "./test_output/test.groups.bar/1.eml",
-        "./test_output/test.groups.bar/2.eml",
-        "./test_output/test.groups.empty",
-        "./test_output/test.groups.empty/__progress.yaml",
-        "./test_output/test.groups.synthetic",
-        "./test_output/test.groups.synthetic/__progress.yaml",
-        "./test_output/test.groups.synthetic/__lineage.yaml",
-        "./test_output/test.groups.synthetic/1.eml",
-        "./test_output/test.groups.synthetic/2.eml",
-        "./test_output/test.groups.synthetic/3.eml",
-        "./test_output/test.groups.synthetic/4.eml",
-        "./test_output/test.groups.synthetic/5.eml",
-        "./test_output/test.groups.synthetic/6.eml",
-        "./test_output/test.groups.synthetic/7.eml",
-        "./test_output/test.groups.synthetic/8.eml",
-        "./test_output/test.groups.synthetic/9.eml",
-        "./test_output/test.groups.synthetic/10.eml",
-        "./test_output/test.groups.synthetic/11.eml",
-        "./test_output/test.groups.synthetic/12.eml",
-    ];
+    let mut expected_files = [
+        root_dir("./test_output"),
+        list_entry("./test_output", "test.groups.foo", &[1, 2], false),
+        list_entry("./test_output", "test.groups.bar", &[1, 2], false),
+        list_entry("./test_output", "test.groups.empty", &[], false),
+        // __progress.yaml is created for empty lists in handle_group via last_processed_id()
+        vec!["./test_output/test.groups.empty/__progress.yaml".to_string()],
+        list_entry(
+            "./test_output",
+            "test.groups.synthetic",
+            &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+            false,
+        ),
+    ]
+    .concat();
     found_files.sort();
     expected_files.sort();
     assert_eq!(found_files, expected_files);
 
     // Validate progress and lineage file content
-    validate_progress_file(
-        "./test_output/test.groups.foo/__progress.yaml",
-        2,
-    );
-    validate_progress_file(
-        "./test_output/test.groups.bar/__progress.yaml",
-        2,
-    );
+    validate_list("./test_output", "test.groups.foo", &[1, 2]);
+    validate_list("./test_output", "test.groups.bar", &[1, 2]);
+    // empty list: __progress.yaml created via last_processed_id() even with 0 articles
     validate_progress_file(
         "./test_output/test.groups.empty/__progress.yaml",
         0,
     );
-    validate_progress_file(
-        "./test_output/test.groups.synthetic/__progress.yaml",
-        12,
-    );
-
-    validate_lineage_file(
-        "./test_output/test.groups.foo/__lineage.yaml",
-        "test.groups.foo",
-        &[1, 2],
-    );
-    validate_lineage_file(
-        "./test_output/test.groups.bar/__lineage.yaml",
-        "test.groups.bar",
-        &[1, 2],
-    );
-    // test.groups.empty has no lineage (0 articles fetched)
-    validate_lineage_file(
-        "./test_output/test.groups.synthetic/__lineage.yaml",
+    validate_list(
+        "./test_output",
         "test.groups.synthetic",
         &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
     );
@@ -319,35 +344,24 @@ fn test_read_single_article_by_range() {
 
     // Only article 5 should be fetched (only exists in synthetic list)
     // Other lists will have __errors.csv files because article 5 doesn't exist
-    let mut expected_files = vec![
-        "./test_output_single",
-        "./test_output_single/test.groups.foo",
-        "./test_output_single/test.groups.foo/__errors.csv",
-        "./test_output_single/test.groups.bar",
-        "./test_output_single/test.groups.bar/__errors.csv",
-        "./test_output_single/test.groups.empty",
-        "./test_output_single/test.groups.empty/__errors.csv",
-        "./test_output_single/test.groups.synthetic",
-        "./test_output_single/test.groups.synthetic/__progress.yaml",
-        "./test_output_single/test.groups.synthetic/__lineage.yaml",
-        "./test_output_single/test.groups.synthetic/5.eml",
-    ];
-
+    let mut expected_files = [
+        root_dir("./test_output_single"),
+        list_entry("./test_output_single", "test.groups.foo", &[], true),
+        list_entry("./test_output_single", "test.groups.bar", &[], true),
+        list_entry("./test_output_single", "test.groups.empty", &[], true),
+        list_entry("./test_output_single", "test.groups.synthetic", &[5], false),
+    ]
+    .concat();
     let mut found_files = found_files;
     found_files.sort();
     expected_files.sort();
     assert_eq!(found_files, expected_files);
 
     // Validate progress and lineage
-    validate_progress_file(
-        "./test_output_single/test.groups.synthetic/__progress.yaml",
-        5,
-    );
-    validate_lineage_file(
-        "./test_output_single/test.groups.synthetic/__lineage.yaml",
-        "test.groups.synthetic",
-        &[5],
-    );
+    validate_list("./test_output_single", "test.groups.foo", &[]);
+    validate_list("./test_output_single", "test.groups.bar", &[]);
+    validate_list("./test_output_single", "test.groups.empty", &[]);
+    validate_list("./test_output_single", "test.groups.synthetic", &[5]);
 
     check_and_delete_folder("./test_output_single".to_string()).unwrap();
 }
@@ -359,60 +373,40 @@ fn test_read_article_range() {
     // Articles 1, 2, 3 should be fetched from each list
     // foo has 2 articles (1, 2), bar has 2 (1, 2), synthetic has 3 (1, 2, 3)
     // Lists with unavailable articles will also have __errors.csv files
-    let mut expected_files = vec![
-        "./test_output_range",
-        "./test_output_range/test.groups.foo",
-        "./test_output_range/test.groups.foo/__progress.yaml",
-        "./test_output_range/test.groups.foo/__lineage.yaml",
-        "./test_output_range/test.groups.foo/1.eml",
-        "./test_output_range/test.groups.foo/2.eml",
-        "./test_output_range/test.groups.foo/__errors.csv",
-        "./test_output_range/test.groups.bar",
-        "./test_output_range/test.groups.bar/__progress.yaml",
-        "./test_output_range/test.groups.bar/__lineage.yaml",
-        "./test_output_range/test.groups.bar/1.eml",
-        "./test_output_range/test.groups.bar/2.eml",
-        "./test_output_range/test.groups.bar/__errors.csv",
-        "./test_output_range/test.groups.empty",
-        "./test_output_range/test.groups.empty/__errors.csv",
-        "./test_output_range/test.groups.synthetic",
-        "./test_output_range/test.groups.synthetic/__progress.yaml",
-        "./test_output_range/test.groups.synthetic/__lineage.yaml",
-        "./test_output_range/test.groups.synthetic/1.eml",
-        "./test_output_range/test.groups.synthetic/2.eml",
-        "./test_output_range/test.groups.synthetic/3.eml",
-    ];
-
+    let mut expected_files = [
+        root_dir("./test_output_range"),
+        list_entry(
+            "./test_output_range",
+            "test.groups.foo",
+            &[1, 2],
+            true,
+        ),
+        list_entry(
+            "./test_output_range",
+            "test.groups.bar",
+            &[1, 2],
+            true,
+        ),
+        list_entry("./test_output_range", "test.groups.empty", &[], true),
+        list_entry(
+            "./test_output_range",
+            "test.groups.synthetic",
+            &[1, 2, 3],
+            false,
+        ),
+    ]
+    .concat();
     let mut found_files = found_files;
     found_files.sort();
     expected_files.sort();
     assert_eq!(found_files, expected_files);
 
     // Validate progress and lineage
-    validate_progress_file(
-        "./test_output_range/test.groups.foo/__progress.yaml",
-        2,
-    );
-    validate_lineage_file(
-        "./test_output_range/test.groups.foo/__lineage.yaml",
-        "test.groups.foo",
-        &[1, 2],
-    );
-    validate_progress_file(
-        "./test_output_range/test.groups.bar/__progress.yaml",
-        2,
-    );
-    validate_lineage_file(
-        "./test_output_range/test.groups.bar/__lineage.yaml",
-        "test.groups.bar",
-        &[1, 2],
-    );
-    validate_progress_file(
-        "./test_output_range/test.groups.synthetic/__progress.yaml",
-        3,
-    );
-    validate_lineage_file(
-        "./test_output_range/test.groups.synthetic/__lineage.yaml",
+    validate_list("./test_output_range", "test.groups.foo", &[1, 2]);
+    validate_list("./test_output_range", "test.groups.bar", &[1, 2]);
+    validate_list("./test_output_range", "test.groups.empty", &[]);
+    validate_list(
+        "./test_output_range",
         "test.groups.synthetic",
         &[1, 2, 3],
     );
@@ -427,58 +421,40 @@ fn test_read_multiple_articles_by_range() {
     // Articles 1, 5, 10 should be fetched from each list
     // foo has 1 article (1), bar has 1 (1), synthetic has 3 (1, 5, 10)
     // Lists with unavailable articles will also have __errors.csv files
-    let mut expected_files = vec![
-        "./test_output_multiple",
-        "./test_output_multiple/test.groups.foo",
-        "./test_output_multiple/test.groups.foo/__progress.yaml",
-        "./test_output_multiple/test.groups.foo/__lineage.yaml",
-        "./test_output_multiple/test.groups.foo/1.eml",
-        "./test_output_multiple/test.groups.foo/__errors.csv",
-        "./test_output_multiple/test.groups.bar",
-        "./test_output_multiple/test.groups.bar/__progress.yaml",
-        "./test_output_multiple/test.groups.bar/__lineage.yaml",
-        "./test_output_multiple/test.groups.bar/1.eml",
-        "./test_output_multiple/test.groups.bar/__errors.csv",
-        "./test_output_multiple/test.groups.empty",
-        "./test_output_multiple/test.groups.empty/__errors.csv",
-        "./test_output_multiple/test.groups.synthetic",
-        "./test_output_multiple/test.groups.synthetic/__progress.yaml",
-        "./test_output_multiple/test.groups.synthetic/__lineage.yaml",
-        "./test_output_multiple/test.groups.synthetic/1.eml",
-        "./test_output_multiple/test.groups.synthetic/5.eml",
-        "./test_output_multiple/test.groups.synthetic/10.eml",
-    ];
-
+    let mut expected_files = [
+        root_dir("./test_output_multiple"),
+        list_entry(
+            "./test_output_multiple",
+            "test.groups.foo",
+            &[1],
+            true,
+        ),
+        list_entry(
+            "./test_output_multiple",
+            "test.groups.bar",
+            &[1],
+            true,
+        ),
+        list_entry("./test_output_multiple", "test.groups.empty", &[], true),
+        list_entry(
+            "./test_output_multiple",
+            "test.groups.synthetic",
+            &[1, 5, 10],
+            false,
+        ),
+    ]
+    .concat();
     let mut found_files = found_files;
     found_files.sort();
     expected_files.sort();
     assert_eq!(found_files, expected_files);
 
     // Validate progress and lineage
-    validate_progress_file(
-        "./test_output_multiple/test.groups.foo/__progress.yaml",
-        1,
-    );
-    validate_lineage_file(
-        "./test_output_multiple/test.groups.foo/__lineage.yaml",
-        "test.groups.foo",
-        &[1],
-    );
-    validate_progress_file(
-        "./test_output_multiple/test.groups.bar/__progress.yaml",
-        1,
-    );
-    validate_lineage_file(
-        "./test_output_multiple/test.groups.bar/__lineage.yaml",
-        "test.groups.bar",
-        &[1],
-    );
-    validate_progress_file(
-        "./test_output_multiple/test.groups.synthetic/__progress.yaml",
-        10,
-    );
-    validate_lineage_file(
-        "./test_output_multiple/test.groups.synthetic/__lineage.yaml",
+    validate_list("./test_output_multiple", "test.groups.foo", &[1]);
+    validate_list("./test_output_multiple", "test.groups.bar", &[1]);
+    validate_list("./test_output_multiple", "test.groups.empty", &[]);
+    validate_list(
+        "./test_output_multiple",
         "test.groups.synthetic",
         &[1, 5, 10],
     );
@@ -493,60 +469,40 @@ fn test_read_mixed_range() {
     // Articles 1, 3, 4, 5, 10 should be fetched from each list
     // foo has 1 article (1), bar has 1 (1), synthetic has 5 (1, 3, 4, 5, 10)
     // Lists with unavailable articles will also have __errors.csv files
-    let mut expected_files = vec![
-        "./test_output_mixed",
-        "./test_output_mixed/test.groups.foo",
-        "./test_output_mixed/test.groups.foo/__progress.yaml",
-        "./test_output_mixed/test.groups.foo/__lineage.yaml",
-        "./test_output_mixed/test.groups.foo/1.eml",
-        "./test_output_mixed/test.groups.foo/__errors.csv",
-        "./test_output_mixed/test.groups.bar",
-        "./test_output_mixed/test.groups.bar/__progress.yaml",
-        "./test_output_mixed/test.groups.bar/__lineage.yaml",
-        "./test_output_mixed/test.groups.bar/1.eml",
-        "./test_output_mixed/test.groups.bar/__errors.csv",
-        "./test_output_mixed/test.groups.empty",
-        "./test_output_mixed/test.groups.empty/__errors.csv",
-        "./test_output_mixed/test.groups.synthetic",
-        "./test_output_mixed/test.groups.synthetic/__progress.yaml",
-        "./test_output_mixed/test.groups.synthetic/__lineage.yaml",
-        "./test_output_mixed/test.groups.synthetic/1.eml",
-        "./test_output_mixed/test.groups.synthetic/3.eml",
-        "./test_output_mixed/test.groups.synthetic/4.eml",
-        "./test_output_mixed/test.groups.synthetic/5.eml",
-        "./test_output_mixed/test.groups.synthetic/10.eml",
-    ];
-
+    let mut expected_files = [
+        root_dir("./test_output_mixed"),
+        list_entry(
+            "./test_output_mixed",
+            "test.groups.foo",
+            &[1],
+            true,
+        ),
+        list_entry(
+            "./test_output_mixed",
+            "test.groups.bar",
+            &[1],
+            true,
+        ),
+        list_entry("./test_output_mixed", "test.groups.empty", &[], true),
+        list_entry(
+            "./test_output_mixed",
+            "test.groups.synthetic",
+            &[1, 3, 4, 5, 10],
+            false,
+        ),
+    ]
+    .concat();
     let mut found_files = found_files;
     found_files.sort();
     expected_files.sort();
     assert_eq!(found_files, expected_files);
 
     // Validate progress and lineage
-    validate_progress_file(
-        "./test_output_mixed/test.groups.foo/__progress.yaml",
-        1,
-    );
-    validate_lineage_file(
-        "./test_output_mixed/test.groups.foo/__lineage.yaml",
-        "test.groups.foo",
-        &[1],
-    );
-    validate_progress_file(
-        "./test_output_mixed/test.groups.bar/__progress.yaml",
-        1,
-    );
-    validate_lineage_file(
-        "./test_output_mixed/test.groups.bar/__lineage.yaml",
-        "test.groups.bar",
-        &[1],
-    );
-    validate_progress_file(
-        "./test_output_mixed/test.groups.synthetic/__progress.yaml",
-        10,
-    );
-    validate_lineage_file(
-        "./test_output_mixed/test.groups.synthetic/__lineage.yaml",
+    validate_list("./test_output_mixed", "test.groups.foo", &[1]);
+    validate_list("./test_output_mixed", "test.groups.bar", &[1]);
+    validate_list("./test_output_mixed", "test.groups.empty", &[]);
+    validate_list(
+        "./test_output_mixed",
         "test.groups.synthetic",
         &[1, 3, 4, 5, 10],
     );
@@ -610,29 +566,22 @@ fn test_read_from_local_nntp_server_with_auth() {
 
     println!("Loading list of files (auth test)");
     let mut found_files = file_list_dir(output_dir.clone());
-    // Verify that files were created (same expected files as the non-auth test)
-    let mut expected_files = vec![
-        "./test_output_auth",
-        "./test_output_auth/test.groups.foo",
-        "./test_output_auth/test.groups.foo/__progress.yaml",
-        "./test_output_auth/test.groups.foo/__lineage.yaml",
-        "./test_output_auth/test.groups.foo/1.eml",
-        "./test_output_auth/test.groups.foo/2.eml",
-    ];
+    let mut expected_files = [
+        root_dir("./test_output_auth"),
+        list_entry(
+            "./test_output_auth",
+            "test.groups.foo",
+            &[1, 2],
+            false,
+        ),
+    ]
+    .concat();
     found_files.sort();
     expected_files.sort();
     assert_eq!(found_files, expected_files);
 
     // Validate progress and lineage
-    validate_progress_file(
-        "./test_output_auth/test.groups.foo/__progress.yaml",
-        2,
-    );
-    validate_lineage_file(
-        "./test_output_auth/test.groups.foo/__lineage.yaml",
-        "test.groups.foo",
-        &[1, 2],
-    );
+    validate_list("./test_output_auth", "test.groups.foo", &[1, 2]);
 
     check_and_delete_folder(output_dir).unwrap();
 }

--- a/mlh_archiver/tests/test_shutdown.rs
+++ b/mlh_archiver/tests/test_shutdown.rs
@@ -1,24 +1,11 @@
 // Tests for shutdown flag functionality
 
-use mlh_archiver::worker::is_shutdown_requested;
 use std::sync::{
     Arc,
     atomic::{AtomicBool, Ordering},
 };
 use std::thread;
 use std::time::Duration;
-
-#[test]
-fn test_is_shutdown_requested_helper() {
-    let shutdown_flag = Arc::new(AtomicBool::new(false));
-
-    // Initially not set
-    assert!(!is_shutdown_requested(&shutdown_flag));
-
-    // Set the flag
-    shutdown_flag.store(true, Ordering::Relaxed);
-    assert!(is_shutdown_requested(&shutdown_flag));
-}
 
 #[test]
 fn test_shutdown_flag_clone_shares_state() {

--- a/mlh_parser/src/mlh_parser/parser.py
+++ b/mlh_parser/src/mlh_parser/parser.py
@@ -61,9 +61,9 @@ def parse_mail_at(mailing_list, input_dir_path, output_dir_path, fail_on_parsing
             for f in all_emails
             if f
             not in (
-                "__last_article_number",
+                "__progress.yaml",
                 "errors.md",
-                "__errors",
+                "__errors.csv",
                 "errors.txt",
             )
             and os.path.isfile(os.path.join(list_input_path, f))

--- a/mlh_parser/src/sanity_check.py
+++ b/mlh_parser/src/sanity_check.py
@@ -39,11 +39,11 @@ def get_list_len(mailing_list):
     list_input_path = INPUT_DIR_PATH + "/" + mailing_list
 
     all_emails = os.listdir(list_input_path)
-    all_emails.remove("__last_article_number")
+    all_emails.remove("__progress.yaml")
     if "errors.md" in all_emails:
         all_emails.remove("errors.md")
-    if "__errors" in all_emails:
-        all_emails.remove("__errors")
+    if "__errors.csv" in all_emails:
+        all_emails.remove("__errors.csv")
     if "errors.txt" in all_emails:
         all_emails.remove("errors.txt")
 


### PR DESCRIPTION
 ArchiveWriter — The Reusable Storage Interface

**All worker implementations MUST use [`ArchiveWriter`](src/archive_writer/) for:**
- Writing fetched emails to disk (`.eml` files)
- Tracking progress (`__progress.yaml` YAML)
- Logging errors for unavailable articles (`__errors.csv` CSV)

The `ArchiveWriter` provides a consistent storage interface so that:
1. Progress is tracked uniformly across all sources
2. Resume from last position works the same way regardless of source
3. File layout is consistent across all implementations