### PR TITLE
Archiver - Tracing with OpenTelemetry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1123,13 +1123,16 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1328,6 +1331,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1437,6 +1456,12 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128fmt"
@@ -1551,10 +1576,20 @@ dependencies = [
  "inquire",
  "log",
  "nntp",
+ "opentelemetry",
+ "opentelemetry-appender-tracing",
+ "opentelemetry-otlp",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry-stdout",
+ "opentelemetry_sdk",
  "serde",
  "serde_yaml",
  "testcontainers",
  "thiserror 2.0.18",
+ "tracing",
+ "tracing-core",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
  "walkdir",
 ]
 
@@ -1580,6 +1615,15 @@ dependencies = [
  "rustls-platform-verifier",
  "strum",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1699,6 +1743,107 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "opentelemetry"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-appender-tracing"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef6a1ac5ca3accf562b8c306fa8483c85f4390f768185ab775f242f7fe8fdcc2"
+dependencies = [
+ "opentelemetry",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "opentelemetry",
+ "reqwest",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
+dependencies = [
+ "http",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "reqwest",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
+ "tonic-prost",
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e62e29dfe041afb8ed2a6c9737ab57db4907285d999ef8ad3a59092a36bdc846"
+
+[[package]]
+name = "opentelemetry-stdout"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc8887887e169414f637b18751487cce4e095be787d23fad13c454e2fb1b3811"
+dependencies = [
+ "chrono",
+ "opentelemetry",
+ "opentelemetry_sdk",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "rand 0.9.4",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "parse-display"
@@ -1999,6 +2144,40 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "ring"
@@ -2316,6 +2495,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2431,6 +2619,9 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -2522,6 +2713,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -2727,6 +2927,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "tower-layer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2767,6 +2985,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+dependencies = [
+ "js-sys",
+ "opentelemetry",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -2870,6 +3130,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2929,6 +3195,16 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2995,6 +3271,16 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.97"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ The archiver is implemented in Rust and uses a forked NNTP library ([`rust-nntp`
 
 - **Multi-threaded**: Each worker thread handles one mailing list at a time
 - **Respectful**: Not designed to pull emails as fast as possible to avoid being detected as a malicious scraping bot
-- **Continuous**: Can keep local files up-to-date with new articles
+- **Continuous**: Can keep local files up-to-date with new emails
 - **Graceful shutdown**: Clean exit on Ctrl+C with progress preservation
 
 **Architecture:**
@@ -333,11 +333,11 @@ The archiver is implemented in Rust and uses a forked NNTP library ([`rust-nntp`
 The archiver uses a nested configuration format:
 
 - Global settings (`nthreads`, `output_dir`, `loop_groups`,`read_lists`) at the top level
-- NNTP-specific settings (`hostname`, `port`, `article_range`) under the `nntp:` block
+- NNTP-specific settings (`hostname`, `port`, `email_range`) under the `nntp:` block
 
-**Article Range Selection:**
+**email Range Selection:**
 
-The `article_range` option allows fetching specific articles instead of all new emails:
+The `email_range` option allows fetching specific emails instead of all new emails:
 
 - Single numbers: `"100"`
 - Ranges: `"1-50"`

--- a/example_archiver_config.yaml
+++ b/example_archiver_config.yaml
@@ -18,7 +18,7 @@ read_lists:
 
 nntp:
   hostname: "nntp://localhost"
-  # article_range: "1-100"  # Optional: fetch specific range from first list
+  # email_range: "1-100"  # Optional: fetch specific range from first list
 
 public_inbox:
   origin: public-inbox.example.org

--- a/mlh_archiver/Cargo.toml
+++ b/mlh_archiver/Cargo.toml
@@ -33,9 +33,36 @@ serde_yaml = "0.9"
 thiserror = "2.0"
 git2 = { version = "0.20", default-features = false, features = ["vendored-libgit2"]}
 
+tracing = { version="0.1.44", features=["attributes"], optional=true}
+tracing-subscriber = { version="0.3.23", optional=true}
+opentelemetry = { version="0.31", optional=true }
+opentelemetry_sdk = { version="0.31", optional=true }
+opentelemetry-stdout = {version="0.31", optional=true}
+opentelemetry-appender-tracing = { version="0.31", optional=true}
+opentelemetry-otlp = { version="0.31.1", features=["http-proto", "reqwest-blocking-client"], optional=true }
+opentelemetry-semantic-conventions = { version="0.31.0", optional=true }
+tracing-core = { version="0.1.36", optional=true }
+tracing-opentelemetry = { version="0.32.1", optional=true }
+
+
 [dev-dependencies]
 testcontainers = { version =  "0.27" , features = ["blocking"] }
 walkdir = "2.5"
 
 [build-dependencies]
 built = { version = "0.8", features = ["cargo-lock", "dependency-tree", "chrono", "semver",  "git2"] }
+
+[features]
+default = []
+otel = [
+	"dep:tracing",
+	"dep:tracing-subscriber",
+	"dep:opentelemetry",
+	"dep:opentelemetry_sdk",
+	"dep:opentelemetry-stdout",
+	"dep:opentelemetry-appender-tracing",
+	"dep:opentelemetry-otlp",
+	"dep:opentelemetry-semantic-conventions",
+	"dep:tracing-core",
+	"dep:tracing-opentelemetry"
+]

--- a/mlh_archiver/README.md
+++ b/mlh_archiver/README.md
@@ -721,6 +721,293 @@ Enable debug logging for troubleshooting:
 RUST_LOG=debug cargo run -- -c archiver_config.yaml
 ```
 
+## OpenTelemetry Tracing
+
+The archiver includes optional OpenTelemetry instrumentation via the `otel` Cargo feature. When enabled, it collects traces using the `tracing` crate and exports them to any OpenTelemetry-compatible backend.
+
+### Building and Running
+
+```bash
+# Build with tracing support
+cargo build --features=otel
+
+# Run with default endpoint (http://localhost:4318)
+cargo run --features=otel -- -c archiver_config.yaml
+
+# Run with a custom OTLP endpoint
+OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger.example.com:4318 cargo run --features=otel -- -c archiver_config.yaml
+```
+
+### Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP HTTP endpoint URL | `http://localhost:4318` |
+| `RUST_LOG` | Log level (also affects trace verbosity) | `info` |
+
+### Quickstart with Jaeger
+
+The easiest way to visualize traces is to run Jaeger's all-in-one Docker image:
+
+```bash
+docker run --rm -d --name jaeger \
+  -e COLLECTOR_OTLP_ENABLED=true \
+  -p 16686:16686 \
+  -p 4318:4318 \
+  jaegertracing/all-in-one:latest
+```
+
+Then run the archiver:
+
+```bash
+cargo run --features=otel -- -c archiver_config.yaml
+```
+
+Open <http://localhost:16686> in your browser to view traces.
+
+### Compatible Backends
+
+OpenTelemetry is an open standard. Any OTLP HTTP-compatible backend works. For a simple local setup, we recommend [Jaeger](https://www.jaegertracing.io/).
+
+### Adding Tracing to New Code
+
+The `tracing` crate is used to instrument code. When the `otel` feature is enabled, `tracing` events and spans are automatically exported as OpenTelemetry traces.
+
+#### Using `#[instrument]`
+
+The simplest way to add tracing is the `#[instrument]` attribute:
+
+```rust
+#[cfg_attr(feature = "otel", tracing::instrument)]
+fn my_function() {
+    // Function body — a span is automatically created
+}
+```
+
+#### Creating Spans Manually
+
+For more control, create spans explicitly:
+
+```rust
+#[cfg_attr(feature = "otel", tracing::instrument)]
+fn process_list(list_name: &str) {
+    tracing::info!("processing list: {}", list_name);
+    // ...
+}
+```
+
+#### Adding Fields to Spans
+
+```rust
+#[cfg_attr(feature = "otel", tracing::instrument(fields(list = %list_name)))]
+fn process_list(list_name: &str) {
+    // The `list` field appears in the span metadata
+}
+```
+
+#### Key Points
+
+- All existing `log::info!`, `log::debug!`, etc. calls are captured as OpenTelemetry log events within spans
+- Spans are exported synchronously via `SimpleSpanProcessor` — no async runtime is required
+- The `otel` module in `src/otel.rs` handles initialization. To add new exporters or layers, modify that file
+- When `otel` is not enabled, the application falls back to `env_logger` for console logging only
+
+## OpenTelemetry Tracing
+
+The archiver includes optional OpenTelemetry instrumentation via the `otel` Cargo feature. When enabled, it collects traces using the `tracing` crate and exports them to any OpenTelemetry-compatible backend.
+
+### Building and Running
+
+```bash
+# Build with tracing support
+cargo build --features=otel
+
+# Run with default endpoint (http://localhost:4318)
+cargo run --features=otel -- -c archiver_config.yaml
+
+# Run with a custom OTLP endpoint
+OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger.example.com:4318 cargo run --features=otel -- -c archiver_config.yaml
+```
+
+### Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP HTTP endpoint URL | `http://localhost:4318` |
+| `RUST_LOG` | Log level (also affects trace verbosity) | `info` |
+
+### Quickstart with Jaeger
+
+The easiest way to visualize traces is to run Jaeger's all-in-one Docker image:
+
+```bash
+docker run --rm -d --name jaeger \
+  -e COLLECTOR_OTLP_ENABLED=true \
+  -p 16686:16686 \
+  -p 4318:4318 \
+  jaegertracing/all-in-one:latest
+```
+
+Then run the archiver:
+
+```bash
+cargo run --features=otel -- -c archiver_config.yaml
+```
+
+Open <http://localhost:16686> in your browser to view traces.
+
+### Compatible Backends
+
+OpenTelemetry is an open standard. Any OTLP HTTP-compatible backend works, including:
+
+- [Jaeger](https://www.jaegertracing.io/)
+- [Grafana Tempo](https://grafana.com/oss/tempo/)
+- [Honeycomb](https://www.honeycomb.io/)
+- [Datadog](https://www.datadoghq.com/)
+- [AWS X-Ray](https://aws.amazon.com/xray/)
+- [Zipkin](https://zipkin.io/) (via OTLP translation)
+
+### Adding Tracing to New Code
+
+The `tracing` crate is used to instrument code. When the `otel` feature is enabled, `tracing` events and spans are automatically exported as OpenTelemetry traces.
+
+#### Using `#[instrument]`
+
+The simplest way to add tracing is the `#[instrument]` attribute:
+
+```rust
+#[cfg_attr(feature = "otel", tracing::instrument)]
+fn my_function() {
+    // Function body — a span is automatically created
+}
+```
+
+#### Creating Spans Manually
+
+For more control, create spans explicitly:
+
+```rust
+#[cfg_attr(feature = "otel", tracing::instrument)]
+fn process_list(list_name: &str) {
+    tracing::info!("processing list: {}", list_name);
+    // ...
+}
+```
+
+#### Adding Fields to Spans
+
+```rust
+#[cfg_attr(feature = "otel", tracing::instrument(fields(list = %list_name)))]
+fn process_list(list_name: &str) {
+    // The `list` field appears in the span metadata
+}
+```
+
+#### Key Points
+
+- All existing `log::info!`, `log::debug!`, etc. calls are captured as OpenTelemetry log events within spans
+- Spans are exported synchronously via `SimpleSpanProcessor` — no async runtime is required
+- The `otel` module in `src/otel.rs` handles initialization. To add new exporters or layers, modify that file
+- When `otel` is not enabled, the application falls back to `env_logger` for console logging only
+
+## OpenTelemetry Tracing
+
+The archiver includes optional OpenTelemetry instrumentation via the `otel` Cargo feature. When enabled, it collects traces using the `tracing` crate and exports them to any OpenTelemetry-compatible backend.
+
+### Building and Running
+
+```bash
+# Build with tracing support
+cargo build --features=otel
+
+# Run with default endpoint (http://localhost:4318)
+cargo run --features=otel -- -c archiver_config.yaml
+
+# Run with a custom OTLP endpoint
+OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger.example.com:4318 cargo run --features=otel -- -c archiver_config.yaml
+```
+
+### Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP HTTP endpoint URL | `http://localhost:4318` |
+| `RUST_LOG` | Log level (also affects trace verbosity) | `info` |
+
+### Quickstart with Jaeger
+
+The easiest way to visualize traces is to run Jaeger's all-in-one Docker image:
+
+```bash
+docker run --rm -d --name jaeger \
+  -e COLLECTOR_OTLP_ENABLED=true \
+  -p 16686:16686 \
+  -p 4318:4318 \
+  jaegertracing/all-in-one:latest
+```
+
+Then run the archiver:
+
+```bash
+cargo run --features=otel -- -c archiver_config.yaml
+```
+
+Open <http://localhost:16686> in your browser to view traces.
+
+### Compatible Backends
+
+OpenTelemetry is an open standard. Any OTLP HTTP-compatible backend works, including:
+
+- [Jaeger](https://www.jaegertracing.io/)
+- [Grafana Tempo](https://grafana.com/oss/tempo/)
+- [Honeycomb](https://www.honeycomb.io/)
+- [Datadog](https://www.datadoghq.com/)
+- [AWS X-Ray](https://aws.amazon.com/xray/)
+- [Zipkin](https://zipkin.io/) (via OTLP translation)
+
+### Adding Tracing to New Code
+
+The `tracing` crate is used to instrument code. When the `otel` feature is enabled, `tracing` events and spans are automatically exported as OpenTelemetry traces.
+
+#### Using `#[instrument]`
+
+The simplest way to add tracing is the `#[instrument]` attribute:
+
+```rust
+#[cfg_attr(feature = "otel", tracing::instrument)]
+fn my_function() {
+    // Function body — a span is automatically created
+}
+```
+
+#### Creating Spans Manually
+
+For more control, create spans explicitly:
+
+```rust
+#[cfg_attr(feature = "otel", tracing::instrument)]
+fn process_list(list_name: &str) {
+    tracing::info!("processing list: {}", list_name);
+    // ...
+}
+```
+
+#### Adding Fields to Spans
+
+```rust
+#[cfg_attr(feature = "otel", tracing::instrument(fields(list = %list_name)))]
+fn process_list(list_name: &str) {
+    // The `list` field appears in the span metadata
+}
+```
+
+#### Key Points
+
+- All existing `log::info!`, `log::debug!`, etc. calls are captured as OpenTelemetry log events within spans
+- Spans are exported synchronously via `SimpleSpanProcessor` — no async runtime is required
+- The `otel` module in `src/otel.rs` handles initialization. To add new exporters or layers, modify that file
+- When `otel` is not enabled, the application falls back to `env_logger` for console logging only
+
 ## License
 
 See the root [LICENSE](../LICENSE) file.

--- a/mlh_archiver/README.md
+++ b/mlh_archiver/README.md
@@ -183,6 +183,22 @@ It is expected that
 | `public_inbox_config` | string | Optional.  TODO: public-inbox configuration file, to automatically select lists |
 | `article_range` | string | Optional. Read specific range of articles (e.g., `"1-100"` or `"1,5,10-20"`) |
 
+#### Public-Inbox Options (under `public_inbox:` block)
+
+If using a large number of public-inbox repositores, we recommend cloning them with [Grokmirror](https://github.com/mricon/grokmirror).
+We have our complete guide available in the [linux-duks/Public-Inbox-Stack](https://github.com/linux-duks/Public-Inbox-Stack). If using only for this, follow the mirroring steps only.
+
+It is expected that
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `import_directory` | string | **Required.** The parent folder of all mailing lists|
+| `origin` | string | **Required**. server hostname were the lists were cloned from |
+| `public_inbox_config` | string | Optional.  TODO: public-inbox configuration file, to automatically select lists |
+| `group_lists` | list | Mailing list names to archive (e.g., `["*"]` for all, or specific lists/globs) |
+| `article_range` | string | Optional. Read specific range of articles (e.g., `"1-100"` or `"1,5,10-20"`) |
+
+
 #### NNTP Options (under `nntp:` block)
 
 | Option | Type | Description |

--- a/mlh_archiver/README.md
+++ b/mlh_archiver/README.md
@@ -1,13 +1,10 @@
 # MLH Archiver
 
 A multi-threaded Rust application for archiving mailing list emails from a few different sources.
+The MLH Archiver fetches emails from the configured source (e.g., NNTP servers) and saves them from specified mailing lists as raw email files.
 
 - NNTP (Network News Transfer Protocol) servers.
 - Public-Inbox Local Git Repositories
-
-## Overview
-
-The MLH Archiver connects to NNTP servers and downloads emails from specified mailing lists, storing them as raw email files. It's designed to be respectful to NNTP servers by not fetching emails too aggressively, avoiding detection as a malicious scraping bot.
 
 ## Architecture
 
@@ -40,12 +37,12 @@ enabling natural load balancing.
    - At start of each task iteration
    - During reconnection waits (60s)
    - During error recovery waits (10s)
-   - During email fetching (per article)
+   - During email fetching (per email)
 
 ### Design Principles
 
 - **Respectful bandwidth**: Not designed to fetch as fast as possible
-- **Continuous operation**: Can keep local files up-to-date with new articles
+- **Continuous operation**: Can keep local files up-to-date with new emails
 - **Graceful shutdown**: Clean exit on Ctrl+C with progress preservation
 
 See the [architecture diagram](../docs/fluxogram.svg) for a visual representation.
@@ -55,7 +52,7 @@ See the [architecture diagram](../docs/fluxogram.svg) for a visual representatio
 - **Multi-threaded**: Process multiple mailing lists concurrently
 - **Configurable**: Support for JSON, YAML, and TOML configuration files
 - **Interactive TUI**: Select mailing lists from an interactive terminal interface
-- **Flexible article selection**: Read specific article ranges or all articles
+- **Flexible email selection**: Read specific email ranges or all emails
 - **Continuous or one-shot mode**: Loop to keep archives updated or run once
 
 ## Prerequisites
@@ -166,7 +163,7 @@ read_lists:
 |--------|------|-------------|
 | `nthreads` | integer | Number of parallel worker threads (default: 1) |
 | `output_dir` | string | Directory to store archived emails (default: "./output") |
-| `loop_groups` | boolean | Continuously check for new articles (default: true) |
+| `loop_groups` | boolean | Continuously check for new emails (default: true) |
 | `read_lists` | map(source:list) | Mailing list names to archive (e.g., `["*"]` for all, or specific lists/globs) |
 
 #### Public-Inbox Options (under `public_inbox:` block)
@@ -181,7 +178,7 @@ It is expected that
 | `import_directory` | string | **Required.** The parent folder of all mailing lists|
 | `origin` | string | **Required**. server hostname were the lists were cloned from |
 | `public_inbox_config` | string | Optional.  TODO: public-inbox configuration file, to automatically select lists |
-| `article_range` | string | Optional. Read specific range of articles (e.g., `"1-100"` or `"1,5,10-20"`) |
+| `email_range` | string | Optional. Read specific range of emails (e.g., `"1-100"` or `"1,5,10-20"`) |
 
 #### Public-Inbox Options (under `public_inbox:` block)
 
@@ -196,8 +193,7 @@ It is expected that
 | `origin` | string | **Required**. server hostname were the lists were cloned from |
 | `public_inbox_config` | string | Optional.  TODO: public-inbox configuration file, to automatically select lists |
 | `group_lists` | list | Mailing list names to archive (e.g., `["*"]` for all, or specific lists/globs) |
-| `article_range` | string | Optional. Read specific range of articles (e.g., `"1-100"` or `"1,5,10-20"`) |
-
+| `email_range` | string | Optional. Read specific range of emails (e.g., `"1-100"` or `"1,5,10-20"`) |
 
 #### NNTP Options (under `nntp:` block)
 
@@ -206,18 +202,18 @@ It is expected that
 | `hostname` | string | **Required.** NNTP server hostname or IP |
 | `port` | integer | NNTP server port (default: 119) |
 | `read_lists` | list | Mailing list names to archive (e.g., `["*"]` for all, or specific lists/globs) |
-| `article_range` | string | Optional. Read specific range of articles (e.g., `"1-100"` or `"1,5,10-20"`) |
+| `email_range` | string | Optional. Read specific range of emails (e.g., `"1-100"` or `"1,5,10-20"`) |
 | `username` | string | Optional. NNTP server username for authentication |
 | `password` | string | Optional. NNTP server password for authentication |
 
-## Article Range Selection
+## email Range Selection
 
-The `article_range` configuration option allows fetching specific articles instead of all new emails:
+The `email_range` configuration option allows fetching specific emails instead of all new emails:
 
 ```yaml
 nntp:
   hostname: "nntp.example.com"
-  article_range: "1,5,10-15"  # Fetch articles 1, 5, and 10-15
+  email_range: "1,5,10-15"  # Fetch emails 1, 5, and 10-15
 ```
 
 **Supported formats:**
@@ -231,9 +227,9 @@ nntp:
 
 **Use cases:**
 
-- Retry failed articles: `article_range: "42,108,256"`
-- Fetch specific date ranges (if you know article numbers)
-- Test runs with small samples: `article_range: "1-10"`
+- Retry failed emails: `email_range: "42,108,256"`
+- Fetch specific date ranges (if you know email numbers)
+- Test runs with small samples: `email_range: "1-10"`
 
 ## Authentication
 
@@ -289,9 +285,9 @@ cargo test
 **Integration Tests** (`cargo test --test test_nntp`):
 
 - Full list download from mock NNTP server
-- Single article by range (`"5"`)
-- Article range (`"1-3"`)
-- Multiple articles (`"1,5,10"`)
+- Single email by range (`"5"`)
+- email range (`"1-3"`)
+- Multiple emails (`"1,5,10"`)
 - Mixed ranges (`"1,3-5,10"`)
 
 Integration tests use testcontainers to spin up a mock NNTP server. Requires Docker/Podman.
@@ -335,7 +331,7 @@ mlh_archiver/
 │   ├── worker.rs            # Worker trait, WorkerManager ownership
 │   ├── errors.rs            # Error types (Error, ConfigError)
 │   ├── file_utils.rs        # File I/O, YAML serialization
-│   ├── range_inputs.rs      # Article range parsing (lazy iterator)
+│   ├── range_inputs.rs      # email range parsing (lazy iterator)
 │   ├── archive_writer/      # Reusable storage facade (MUST be used by all workers)
 │   │   ├── mod.rs           # ArchiveWriter facade
 │   │   ├── progress.rs      # ProgressTracker (reads/writes __progress.yaml)
@@ -385,7 +381,7 @@ To add a new email source (e.g., ListArchiveX, IMAP, local mbox), follow these s
 
 - Writing fetched emails to disk (`.eml` files)
 - Tracking progress (`__progress.yaml` YAML)
-- Logging errors for unavailable articles (`__errors.csv` CSV)
+- Logging errors for unavailable emails (`__errors.csv` CSV)
 
 The `ArchiveWriter` provides a consistent storage interface so that:
 
@@ -405,17 +401,17 @@ let writer = ArchiveWriter::new(
     &list_name,
 );
 
-// Get last processed article ID (for resume)
+// Get last processed email ID (for resume)
 let last_id = writer.last_processed_id();
 
 // Write a fetched email
-writer.write_email(article_id, &raw_lines)?;
+writer.write_email(email_id, &raw_lines)?;
 
 // Update progress after successful write
-writer.update_progress(article_id)?;
+writer.update_progress(email_id)?;
 
-// Log unavailable articles (non-fatal)
-writer.log_error(article_id, &error.to_string());
+// Log unavailable emails (non-fatal)
+writer.log_error(email_id, &error.to_string());
 ```
 
 **File layout produced by `ArchiveWriter`:**
@@ -423,7 +419,7 @@ writer.log_error(article_id, &error.to_string());
 ```
 output/
 ├── list.name/
-│   ├── 1.eml                    # Fetched article
+│   ├── 1.eml                    # Fetched email
 │   ├── 2.eml
 │   ├── __progress.yaml          # YAML: last processed ID (resume)
 │   ├── __lineage.yaml           # YAML stream: DataLineage audit trail
@@ -454,7 +450,7 @@ pub struct ListArchiveXConfig {
     pub base_url: String,
     pub api_key: Option<String>,
     pub read_lists: Option<Vec<String>>,
-    pub article_range: Option<String>,
+    pub email_range: Option<String>,
 }
 
 impl ListArchiveXConfig {
@@ -547,7 +543,7 @@ impl Worker for ListArchiveXWorker {
             &list_name,
         );
 
-        // Fetch and store the specific article...
+        // Fetch and store the specific email...
         // writer.write_email(email_index, &lines)?;
         // writer.update_progress(email_index)?;
         Ok(())
@@ -747,14 +743,17 @@ OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger.example.com:4318 cargo run --features=
 
 ### Quickstart with Jaeger
 
+OpenTelemetry is an open standard. Any OTLP HTTP-compatible backend works.
 The easiest way to visualize traces is to run Jaeger's all-in-one Docker image:
 
 ```bash
-docker run --rm -d --name jaeger \
-  -e COLLECTOR_OTLP_ENABLED=true \
+podman run --rm --name jaeger \
   -p 16686:16686 \
+  -p 4317:4317 \
   -p 4318:4318 \
-  jaegertracing/all-in-one:latest
+  -p 5778:5778 \
+  -p 9411:9411 \
+  cr.jaegertracing.io/jaegertracing/jaeger:2.17.0
 ```
 
 Then run the archiver:
@@ -764,10 +763,6 @@ cargo run --features=otel -- -c archiver_config.yaml
 ```
 
 Open <http://localhost:16686> in your browser to view traces.
-
-### Compatible Backends
-
-OpenTelemetry is an open standard. Any OTLP HTTP-compatible backend works. For a simple local setup, we recommend [Jaeger](https://www.jaegertracing.io/).
 
 ### Adding Tracing to New Code
 
@@ -784,19 +779,9 @@ fn my_function() {
 }
 ```
 
-#### Creating Spans Manually
+#### Controlling Fields in Spans
 
-For more control, create spans explicitly:
-
-```rust
-#[cfg_attr(feature = "otel", tracing::instrument)]
-fn process_list(list_name: &str) {
-    tracing::info!("processing list: {}", list_name);
-    // ...
-}
-```
-
-#### Adding Fields to Spans
+Adding specific fields:
 
 ```rust
 #[cfg_attr(feature = "otel", tracing::instrument(fields(list = %list_name)))]
@@ -805,206 +790,18 @@ fn process_list(list_name: &str) {
 }
 ```
 
-#### Key Points
-
-- All existing `log::info!`, `log::debug!`, etc. calls are captured as OpenTelemetry log events within spans
-- Spans are exported synchronously via `SimpleSpanProcessor` — no async runtime is required
-- The `otel` module in `src/otel.rs` handles initialization. To add new exporters or layers, modify that file
-- When `otel` is not enabled, the application falls back to `env_logger` for console logging only
-
-## OpenTelemetry Tracing
-
-The archiver includes optional OpenTelemetry instrumentation via the `otel` Cargo feature. When enabled, it collects traces using the `tracing` crate and exports them to any OpenTelemetry-compatible backend.
-
-### Building and Running
-
-```bash
-# Build with tracing support
-cargo build --features=otel
-
-# Run with default endpoint (http://localhost:4318)
-cargo run --features=otel -- -c archiver_config.yaml
-
-# Run with a custom OTLP endpoint
-OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger.example.com:4318 cargo run --features=otel -- -c archiver_config.yaml
-```
-
-### Environment Variables
-
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP HTTP endpoint URL | `http://localhost:4318` |
-| `RUST_LOG` | Log level (also affects trace verbosity) | `info` |
-
-### Quickstart with Jaeger
-
-The easiest way to visualize traces is to run Jaeger's all-in-one Docker image:
-
-```bash
-docker run --rm -d --name jaeger \
-  -e COLLECTOR_OTLP_ENABLED=true \
-  -p 16686:16686 \
-  -p 4318:4318 \
-  jaegertracing/all-in-one:latest
-```
-
-Then run the archiver:
-
-```bash
-cargo run --features=otel -- -c archiver_config.yaml
-```
-
-Open <http://localhost:16686> in your browser to view traces.
-
-### Compatible Backends
-
-OpenTelemetry is an open standard. Any OTLP HTTP-compatible backend works, including:
-
-- [Jaeger](https://www.jaegertracing.io/)
-- [Grafana Tempo](https://grafana.com/oss/tempo/)
-- [Honeycomb](https://www.honeycomb.io/)
-- [Datadog](https://www.datadoghq.com/)
-- [AWS X-Ray](https://aws.amazon.com/xray/)
-- [Zipkin](https://zipkin.io/) (via OTLP translation)
-
-### Adding Tracing to New Code
-
-The `tracing` crate is used to instrument code. When the `otel` feature is enabled, `tracing` events and spans are automatically exported as OpenTelemetry traces.
-
-#### Using `#[instrument]`
-
-The simplest way to add tracing is the `#[instrument]` attribute:
+Removing fields - Large entities, or entities that do not implement Debug need to be skipped :
 
 ```rust
-#[cfg_attr(feature = "otel", tracing::instrument)]
-fn my_function() {
-    // Function body — a span is automatically created
-}
-```
+#[cfg_attr(feature = "otel", tracing::instrument(skip(receiver, self)))]
+fn consumme_list(
 
-#### Creating Spans Manually
-
-For more control, create spans explicitly:
-
-```rust
-#[cfg_attr(feature = "otel", tracing::instrument)]
-fn process_list(list_name: &str) {
-    tracing::info!("processing list: {}", list_name);
-    // ...
-}
-```
-
-#### Adding Fields to Spans
-
-```rust
-#[cfg_attr(feature = "otel", tracing::instrument(fields(list = %list_name)))]
-fn process_list(list_name: &str) {
-    // The `list` field appears in the span metadata
-}
 ```
 
 #### Key Points
 
 - All existing `log::info!`, `log::debug!`, etc. calls are captured as OpenTelemetry log events within spans
-- Spans are exported synchronously via `SimpleSpanProcessor` — no async runtime is required
-- The `otel` module in `src/otel.rs` handles initialization. To add new exporters or layers, modify that file
-- When `otel` is not enabled, the application falls back to `env_logger` for console logging only
-
-## OpenTelemetry Tracing
-
-The archiver includes optional OpenTelemetry instrumentation via the `otel` Cargo feature. When enabled, it collects traces using the `tracing` crate and exports them to any OpenTelemetry-compatible backend.
-
-### Building and Running
-
-```bash
-# Build with tracing support
-cargo build --features=otel
-
-# Run with default endpoint (http://localhost:4318)
-cargo run --features=otel -- -c archiver_config.yaml
-
-# Run with a custom OTLP endpoint
-OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger.example.com:4318 cargo run --features=otel -- -c archiver_config.yaml
-```
-
-### Environment Variables
-
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP HTTP endpoint URL | `http://localhost:4318` |
-| `RUST_LOG` | Log level (also affects trace verbosity) | `info` |
-
-### Quickstart with Jaeger
-
-The easiest way to visualize traces is to run Jaeger's all-in-one Docker image:
-
-```bash
-docker run --rm -d --name jaeger \
-  -e COLLECTOR_OTLP_ENABLED=true \
-  -p 16686:16686 \
-  -p 4318:4318 \
-  jaegertracing/all-in-one:latest
-```
-
-Then run the archiver:
-
-```bash
-cargo run --features=otel -- -c archiver_config.yaml
-```
-
-Open <http://localhost:16686> in your browser to view traces.
-
-### Compatible Backends
-
-OpenTelemetry is an open standard. Any OTLP HTTP-compatible backend works, including:
-
-- [Jaeger](https://www.jaegertracing.io/)
-- [Grafana Tempo](https://grafana.com/oss/tempo/)
-- [Honeycomb](https://www.honeycomb.io/)
-- [Datadog](https://www.datadoghq.com/)
-- [AWS X-Ray](https://aws.amazon.com/xray/)
-- [Zipkin](https://zipkin.io/) (via OTLP translation)
-
-### Adding Tracing to New Code
-
-The `tracing` crate is used to instrument code. When the `otel` feature is enabled, `tracing` events and spans are automatically exported as OpenTelemetry traces.
-
-#### Using `#[instrument]`
-
-The simplest way to add tracing is the `#[instrument]` attribute:
-
-```rust
-#[cfg_attr(feature = "otel", tracing::instrument)]
-fn my_function() {
-    // Function body — a span is automatically created
-}
-```
-
-#### Creating Spans Manually
-
-For more control, create spans explicitly:
-
-```rust
-#[cfg_attr(feature = "otel", tracing::instrument)]
-fn process_list(list_name: &str) {
-    tracing::info!("processing list: {}", list_name);
-    // ...
-}
-```
-
-#### Adding Fields to Spans
-
-```rust
-#[cfg_attr(feature = "otel", tracing::instrument(fields(list = %list_name)))]
-fn process_list(list_name: &str) {
-    // The `list` field appears in the span metadata
-}
-```
-
-#### Key Points
-
-- All existing `log::info!`, `log::debug!`, etc. calls are captured as OpenTelemetry log events within spans
-- Spans are exported synchronously via `SimpleSpanProcessor` — no async runtime is required
+- Spans are exported synchronously via `SimpleSpanProcessor` — no async runtime is used
 - The `otel` module in `src/otel.rs` handles initialization. To add new exporters or layers, modify that file
 - When `otel` is not enabled, the application falls back to `env_logger` for console logging only
 

--- a/mlh_archiver/src/archive_writer/data_lineage.rs
+++ b/mlh_archiver/src/archive_writer/data_lineage.rs
@@ -71,6 +71,7 @@ pub(crate) struct DataLineage {
     pub(crate) archiver_build_info: String,
 }
 
+#[derive(std::fmt::Debug)]
 pub struct DataLineageWriter {
     output_path: PathBuf,
     list_name: String,
@@ -98,6 +99,7 @@ impl DataLineageWriter {
     /// # Arguments
     ///
     /// * `id` - email ID that was just processed
+    #[cfg_attr(feature = "otel", tracing::instrument)]
     pub fn update(&self, id: &str) -> crate::Result<()> {
         crate::file_utils::append_yaml_to_file(
             self.output_path.to_str().unwrap(),

--- a/mlh_archiver/src/archive_writer/data_lineage.rs
+++ b/mlh_archiver/src/archive_writer/data_lineage.rs
@@ -99,7 +99,6 @@ impl DataLineageWriter {
     /// # Arguments
     ///
     /// * `id` - email ID that was just processed
-    #[cfg_attr(feature = "otel", tracing::instrument)]
     pub fn update(&self, id: &str) -> crate::Result<()> {
         crate::file_utils::append_yaml_to_file(
             self.output_path.to_str().unwrap(),

--- a/mlh_archiver/src/archive_writer/email_store.rs
+++ b/mlh_archiver/src/archive_writer/email_store.rs
@@ -40,8 +40,6 @@ impl EmailStore {
     ///
     /// * `email_id` - email number
     /// * `lines` - Raw email lines (written without added newlines)
-    
-    #[cfg_attr(feature = "otel", tracing::instrument)]
     pub fn write<I, L>(&self, email_id: &str, lines: I) -> crate::Result<()>
     where
         I: IntoIterator<Item = L> + std::fmt::Debug,

--- a/mlh_archiver/src/archive_writer/email_store.rs
+++ b/mlh_archiver/src/archive_writer/email_store.rs
@@ -16,6 +16,7 @@ use std::path::{Path, PathBuf};
 /// let store = EmailStore::new(Path::new("./output"), "test.list");
 /// store.write("42", &["From: user@example.com".to_string()]).unwrap();
 /// ```
+#[derive(std::fmt::Debug)]
 pub struct EmailStore {
     output_path: PathBuf,
 }
@@ -39,9 +40,11 @@ impl EmailStore {
     ///
     /// * `email_id` - email number
     /// * `lines` - Raw email lines (written without added newlines)
+    
+    #[cfg_attr(feature = "otel", tracing::instrument)]
     pub fn write<I, L>(&self, email_id: &str, lines: I) -> crate::Result<()>
     where
-        I: IntoIterator<Item = L>,
+        I: IntoIterator<Item = L> + std::fmt::Debug,
         L: AsRef<str>,
     {
         let file_path = self.output_path.join(format!("{email_id}.eml"));

--- a/mlh_archiver/src/archive_writer/error_log.rs
+++ b/mlh_archiver/src/archive_writer/error_log.rs
@@ -16,6 +16,7 @@ use std::path::{Path, PathBuf};
 /// let logger = ErrorLogger::new(Path::new("./output"), "test.list");
 /// logger.log("42", "email not available");
 /// ```
+#[derive(std::fmt::Debug)]
 pub struct ErrorLogger {
     output_path: PathBuf,
 }
@@ -42,6 +43,8 @@ impl ErrorLogger {
     ///
     /// * `email_id` - email number that failed
     /// * `error` - Error message
+    
+    #[cfg_attr(feature = "otel", tracing::instrument)]
     pub fn log(&self, email_id: &str, error: &str) {
         let line = format!("{email_id},{error}");
         if let Err(e) = crate::file_utils::append_line_to_file(&self.output_path, &line) {

--- a/mlh_archiver/src/archive_writer/error_log.rs
+++ b/mlh_archiver/src/archive_writer/error_log.rs
@@ -43,8 +43,6 @@ impl ErrorLogger {
     ///
     /// * `email_id` - email number that failed
     /// * `error` - Error message
-    
-    #[cfg_attr(feature = "otel", tracing::instrument)]
     pub fn log(&self, email_id: &str, error: &str) {
         let line = format!("{email_id},{error}");
         if let Err(e) = crate::file_utils::append_line_to_file(&self.output_path, &line) {

--- a/mlh_archiver/src/archive_writer/mod.rs
+++ b/mlh_archiver/src/archive_writer/mod.rs
@@ -143,8 +143,7 @@ impl ArchiveWriter {
     ///
     /// * `email_id` - Email/article number
     /// * `lines` - Raw email lines (can be any iterable collection of strings)
-
-    #[cfg_attr(feature = "otel", tracing::instrument)]
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, lines)))]
     pub fn archive_email<I, L>(&self, email_id: &str, lines: I) -> crate::Result<()>
     where
         I: IntoIterator<Item = L> + std::fmt::Debug,

--- a/mlh_archiver/src/archive_writer/mod.rs
+++ b/mlh_archiver/src/archive_writer/mod.rs
@@ -93,6 +93,7 @@ use std::path::Path;
 /// Instead of workers managing their own file I/O, `ArchiveWriter` provides
 /// a single interface that all workers use. This ensures consistent behavior
 /// across different source implementations (NNTP, IMAP, mbox, etc.).
+#[derive(std::fmt::Debug)]
 pub struct ArchiveWriter {
     progress: ProgressTracker,
     error_log: ErrorLogger,
@@ -142,9 +143,11 @@ impl ArchiveWriter {
     ///
     /// * `email_id` - Email/article number
     /// * `lines` - Raw email lines (can be any iterable collection of strings)
+
+    #[cfg_attr(feature = "otel", tracing::instrument)]
     pub fn archive_email<I, L>(&self, email_id: &str, lines: I) -> crate::Result<()>
     where
-        I: IntoIterator<Item = L>,
+        I: IntoIterator<Item = L> + std::fmt::Debug,
         L: AsRef<str>,
     {
         self.email_store.write(email_id, lines)?;

--- a/mlh_archiver/src/archive_writer/progress.rs
+++ b/mlh_archiver/src/archive_writer/progress.rs
@@ -23,6 +23,7 @@ pub(crate) struct ReadStatus {
 /// let tracker = ProgressTracker::new(Path::new("./output"), "test.list");
 /// let last = tracker.last_processed_id();
 /// ```
+#[derive(std::fmt::Debug)]
 pub struct ProgressTracker {
     output_path: PathBuf,
 }
@@ -46,6 +47,8 @@ impl ProgressTracker {
     /// Also falls back to reading a plain number from the file.
     /// If no file exists, initializes one with `0` to mark the list
     /// as discovered.
+    
+    #[cfg_attr(feature = "otel", tracing::instrument)]
     pub fn last_processed_id(&self) -> Option<String> {
         match crate::file_utils::read_yaml::<ReadStatus>(self.output_path.to_str().unwrap()) {
             Ok(status) => Some(status.last_email),
@@ -65,6 +68,8 @@ impl ProgressTracker {
     /// # Arguments
     ///
     /// * `id` - email ID that was just processed
+    
+    #[cfg_attr(feature = "otel", tracing::instrument)]
     pub fn update(&self, id: &str) -> crate::Result<()> {
         crate::file_utils::write_yaml(
             self.output_path.to_str().unwrap(),

--- a/mlh_archiver/src/archive_writer/progress.rs
+++ b/mlh_archiver/src/archive_writer/progress.rs
@@ -47,8 +47,6 @@ impl ProgressTracker {
     /// Also falls back to reading a plain number from the file.
     /// If no file exists, initializes one with `0` to mark the list
     /// as discovered.
-    
-    #[cfg_attr(feature = "otel", tracing::instrument)]
     pub fn last_processed_id(&self) -> Option<String> {
         match crate::file_utils::read_yaml::<ReadStatus>(self.output_path.to_str().unwrap()) {
             Ok(status) => Some(status.last_email),
@@ -68,8 +66,6 @@ impl ProgressTracker {
     /// # Arguments
     ///
     /// * `id` - email ID that was just processed
-    
-    #[cfg_attr(feature = "otel", tracing::instrument)]
     pub fn update(&self, id: &str) -> crate::Result<()> {
         crate::file_utils::write_yaml(
             self.output_path.to_str().unwrap(),

--- a/mlh_archiver/src/config.rs
+++ b/mlh_archiver/src/config.rs
@@ -149,7 +149,7 @@ impl AppConfig {
         }
     }
 
-    /// Retrieves the article range selection text for a specific run mode.
+    /// Retrieves the email range selection text for a specific run mode.
     ///
     /// The range text is a string like `"1,5,10-15"` that specifies which
     /// articles to fetch. It should be parsed by [`crate::range_inputs::parse_sequence()`]
@@ -165,8 +165,8 @@ impl AppConfig {
     /// * `None` if no range is configured or run mode has no config
     pub fn get_range_selection_text(&self, run_mode: RunMode) -> Option<String> {
         match self.get_run_mode_config(run_mode)? {
-            RunModeConfig::NNTP(nntp_config) => nntp_config.article_range,
-            RunModeConfig::PublicInbox(pi_config) => pi_config.article_range,
+            RunModeConfig::NNTP(nntp_config) => nntp_config.email_range,
+            RunModeConfig::PublicInbox(pi_config) => pi_config.email_range,
             RunModeConfig::LocalMbox => unimplemented!(),
         }
     }

--- a/mlh_archiver/src/file_utils.rs
+++ b/mlh_archiver/src/file_utils.rs
@@ -32,11 +32,9 @@ use std::{
 ///
 /// - Creates parent directories if they don't exist
 /// - Truncates existing file
-
-#[cfg_attr(feature = "otel", tracing::instrument)]
 pub fn write_lines_file<I, L>(file_path: &Path, lines: I) -> io::Result<()>
 where
-    I: IntoIterator<Item = L> + std::fmt::Debug,
+    I: IntoIterator<Item = L>,
     L: AsRef<str>,
 {
     // Create or open (truncate) a file for writing
@@ -71,8 +69,6 @@ where
 ///
 /// * `Ok(())` on success
 /// * `Err(io::Error)` on failure
-
-#[cfg_attr(feature = "otel", tracing::instrument)]
 pub fn append_line_to_file(file_path: &Path, line: &str) -> io::Result<()> {
     // check if parent folder need to be created first
     if let Some(parent) = file_path.parent() {
@@ -109,8 +105,6 @@ pub fn append_line_to_file(file_path: &Path, line: &str) -> io::Result<()> {
 ///
 /// * `Ok(usize)` - The parsed number
 /// * `Err(io::Error)` - File not found, unreadable, or no valid number
-
-#[cfg_attr(feature = "otel", tracing::instrument)]
 pub fn try_read_number(path: &Path) -> Result<usize, io::Error> {
     // Attempt to read the file's content into a string.
     let content = fs::read_to_string(path)?;
@@ -148,11 +142,9 @@ pub fn try_read_number(path: &Path) -> Result<usize, io::Error> {
 ///
 /// - Creates parent directories if needed
 /// - Appends to file (does not truncate)
-
-#[cfg_attr(feature = "otel", tracing::instrument)]
 pub fn write_yaml<T>(file_name: &str, value: &T) -> io::Result<()>
 where
-    T: ?Sized + ser::Serialize + std::fmt::Debug,
+    T: ?Sized + ser::Serialize,
 {
     // check if parent folder need to be created first
     let file_path = Path::new(file_name);
@@ -248,8 +240,6 @@ where
 /// // id: 2
 /// // msg: second
 /// ```
-
-#[cfg_attr(feature = "otel", tracing::instrument)]
 pub fn append_yaml_to_file<T>(file_name: &str, value: &T) -> io::Result<()>
 where
     T: ?Sized + ser::Serialize + std::fmt::Debug,
@@ -286,8 +276,6 @@ where
 ///
 /// * `Ok(T)` - Deserialized value
 /// * `Err(io::Error)` - File not found, unreadable, or invalid YAML
-
-#[cfg_attr(feature = "otel", tracing::instrument)]
 pub fn read_yaml<T>(file_name: &str) -> io::Result<T>
 where
     T: DeserializeOwned,
@@ -316,8 +304,6 @@ where
 ///
 /// - Creates folder and all parent directories if they don't exist
 /// - Logs debug/warn messages about folder existence
-
-#[cfg_attr(feature = "otel", tracing::instrument)]
 pub fn check_or_create_folder(folder_path: String) -> io::Result<()> {
     let p = Path::new(&folder_path);
     if p.exists() {

--- a/mlh_archiver/src/file_utils.rs
+++ b/mlh_archiver/src/file_utils.rs
@@ -32,9 +32,11 @@ use std::{
 ///
 /// - Creates parent directories if they don't exist
 /// - Truncates existing file
+
+#[cfg_attr(feature = "otel", tracing::instrument)]
 pub fn write_lines_file<I, L>(file_path: &Path, lines: I) -> io::Result<()>
 where
-    I: IntoIterator<Item = L>,
+    I: IntoIterator<Item = L> + std::fmt::Debug,
     L: AsRef<str>,
 {
     // Create or open (truncate) a file for writing
@@ -69,6 +71,8 @@ where
 ///
 /// * `Ok(())` on success
 /// * `Err(io::Error)` on failure
+
+#[cfg_attr(feature = "otel", tracing::instrument)]
 pub fn append_line_to_file(file_path: &Path, line: &str) -> io::Result<()> {
     // check if parent folder need to be created first
     if let Some(parent) = file_path.parent() {
@@ -105,6 +109,8 @@ pub fn append_line_to_file(file_path: &Path, line: &str) -> io::Result<()> {
 ///
 /// * `Ok(usize)` - The parsed number
 /// * `Err(io::Error)` - File not found, unreadable, or no valid number
+
+#[cfg_attr(feature = "otel", tracing::instrument)]
 pub fn try_read_number(path: &Path) -> Result<usize, io::Error> {
     // Attempt to read the file's content into a string.
     let content = fs::read_to_string(path)?;
@@ -142,9 +148,11 @@ pub fn try_read_number(path: &Path) -> Result<usize, io::Error> {
 ///
 /// - Creates parent directories if needed
 /// - Appends to file (does not truncate)
+
+#[cfg_attr(feature = "otel", tracing::instrument)]
 pub fn write_yaml<T>(file_name: &str, value: &T) -> io::Result<()>
 where
-    T: ?Sized + ser::Serialize,
+    T: ?Sized + ser::Serialize + std::fmt::Debug,
 {
     // check if parent folder need to be created first
     let file_path = Path::new(file_name);
@@ -228,7 +236,7 @@ where
 /// ```rust,no_run
 /// use mlh_archiver::file_utils::append_yaml_to_file;
 ///
-/// #[derive(serde::Serialize)]
+/// #[derive(serde::Serialize, std::fmt::Debug)]
 /// struct Event { id: usize, msg: String }
 ///
 /// append_yaml_to_file("./events.yaml", &Event { id: 1, msg: "first".to_string() }).unwrap();
@@ -240,9 +248,11 @@ where
 /// // id: 2
 /// // msg: second
 /// ```
+
+#[cfg_attr(feature = "otel", tracing::instrument)]
 pub fn append_yaml_to_file<T>(file_name: &str, value: &T) -> io::Result<()>
 where
-    T: ?Sized + ser::Serialize,
+    T: ?Sized + ser::Serialize + std::fmt::Debug,
 {
     let file_path = Path::new(file_name);
     if let Some(parent) = file_path.parent() {
@@ -276,6 +286,8 @@ where
 ///
 /// * `Ok(T)` - Deserialized value
 /// * `Err(io::Error)` - File not found, unreadable, or invalid YAML
+
+#[cfg_attr(feature = "otel", tracing::instrument)]
 pub fn read_yaml<T>(file_name: &str) -> io::Result<T>
 where
     T: DeserializeOwned,
@@ -304,6 +316,8 @@ where
 ///
 /// - Creates folder and all parent directories if they don't exist
 /// - Logs debug/warn messages about folder existence
+
+#[cfg_attr(feature = "otel", tracing::instrument)]
 pub fn check_or_create_folder(folder_path: String) -> io::Result<()> {
     let p = Path::new(&folder_path);
     if p.exists() {

--- a/mlh_archiver/src/lib.rs
+++ b/mlh_archiver/src/lib.rs
@@ -31,6 +31,9 @@ pub mod range_inputs;
 pub mod scheduler;
 pub mod worker;
 
+#[cfg(feature = "otel")]
+pub mod otel;
+
 pub use errors::Result;
 
 use config::{RunMode, RunModeConfig};
@@ -69,6 +72,7 @@ use worker::WorkerManager;
 /// let shutdown_flag = Arc::new(AtomicBool::new(false));
 /// start(&mut app_config, shutdown_flag).unwrap();
 /// ```
+#[cfg_attr(feature = "otel", tracing::instrument)]
 pub fn start(
     app_config: &mut config::AppConfig,
     shutdown_flag: Arc<AtomicBool>,
@@ -102,6 +106,7 @@ pub fn start(
                     let groups = public_inbox_source::pi_lister::retrieve_lists(pi_config.clone())?;
                     let groups = app_config.get_read_lists(groups, mode)?;
                     log::info!("made a selection of {} {:#?}", groups.len(), groups);
+
                     worker.create_workers(mode, groups, app_config, shutdown_flag.clone());
                 }
             }

--- a/mlh_archiver/src/lib.rs
+++ b/mlh_archiver/src/lib.rs
@@ -72,7 +72,6 @@ use worker::WorkerManager;
 /// let shutdown_flag = Arc::new(AtomicBool::new(false));
 /// start(&mut app_config, shutdown_flag).unwrap();
 /// ```
-#[cfg_attr(feature = "otel", tracing::instrument)]
 pub fn start(
     app_config: &mut config::AppConfig,
     shutdown_flag: Arc<AtomicBool>,

--- a/mlh_archiver/src/main.rs
+++ b/mlh_archiver/src/main.rs
@@ -1,19 +1,29 @@
 #![allow(clippy::needless_return)]
 
+#[cfg(not(feature = "otel"))]
+#[cfg(not(feature = "otel"))]
 use env_logger::Env;
 use std::sync::{
-    Arc,
     atomic::{AtomicBool, Ordering},
+    Arc,
 };
 
-use mlh_archiver::Result;
 use mlh_archiver::config;
+
+#[cfg(feature = "otel")]
+use mlh_archiver::otel;
 use mlh_archiver::start;
+use mlh_archiver::Result;
 
 fn main() -> Result<()> {
-    let env = Env::default().filter_or("RUST_LOG", "info");
+    #[cfg(feature = "otel")]
+    let _guard = otel::init_tracing_subscriber();
 
-    env_logger::init_from_env(env);
+    #[cfg(not(feature = "otel"))]
+    {
+        let env = Env::default().filter_or("RUST_LOG", "info");
+        env_logger::init_from_env(env);
+    }
 
     let mut app_config = match config::read_config() {
         Ok(cfg) => cfg,

--- a/mlh_archiver/src/main.rs
+++ b/mlh_archiver/src/main.rs
@@ -4,16 +4,16 @@
 #[cfg(not(feature = "otel"))]
 use env_logger::Env;
 use std::sync::{
-    atomic::{AtomicBool, Ordering},
     Arc,
+    atomic::{AtomicBool, Ordering},
 };
 
 use mlh_archiver::config;
 
+use mlh_archiver::Result;
 #[cfg(feature = "otel")]
 use mlh_archiver::otel;
 use mlh_archiver::start;
-use mlh_archiver::Result;
 
 fn main() -> Result<()> {
     #[cfg(feature = "otel")]

--- a/mlh_archiver/src/nntp_source/nntp_config.rs
+++ b/mlh_archiver/src/nntp_source/nntp_config.rs
@@ -21,7 +21,7 @@ pub struct NntpConfig {
     pub request_interval: u64,
     /// (optional). Read a specific range of articles from the first list provided.
     /// Comma separated values, or dash separated ranges, like low-high
-    pub article_range: Option<String>,
+    pub email_range: Option<String>,
 
     /// (optional). NNTP server username for authentication
     pub username: Option<String>,

--- a/mlh_archiver/src/nntp_source/nntp_lister.rs
+++ b/mlh_archiver/src/nntp_source/nntp_lister.rs
@@ -1,6 +1,8 @@
 use crate::nntp_source::{nntp_config::NntpConfig, nntp_utils::retrieve_lists_with_connection};
 
 /// retrieve_lists connects to the nntp endpoint, and returns the name of every list available
+
+#[cfg_attr(feature = "otel", tracing::instrument)]
 pub fn retrieve_lists(nntp_config: NntpConfig) -> crate::errors::Result<Vec<String>> {
     // Get NNTP config (validates hostname is present)
     nntp_config.validate()?;

--- a/mlh_archiver/src/nntp_source/nntp_lister.rs
+++ b/mlh_archiver/src/nntp_source/nntp_lister.rs
@@ -1,7 +1,6 @@
 use crate::nntp_source::{nntp_config::NntpConfig, nntp_utils::retrieve_lists_with_connection};
 
 /// retrieve_lists connects to the nntp endpoint, and returns the name of every list available
-
 #[cfg_attr(feature = "otel", tracing::instrument)]
 pub fn retrieve_lists(nntp_config: NntpConfig) -> crate::errors::Result<Vec<String>> {
     // Get NNTP config (validates hostname is present)

--- a/mlh_archiver/src/nntp_source/nntp_utils.rs
+++ b/mlh_archiver/src/nntp_source/nntp_utils.rs
@@ -37,6 +37,8 @@ use nntp::NNTPStream;
 /// stream.quit()?;
 /// # Ok::<(), mlh_archiver::errors::Error>(())
 /// ```
+
+#[cfg_attr(feature = "otel", tracing::instrument)]
 pub fn connect_to_nntp_server(
     hostname: &str,
     port: Option<u16>,
@@ -107,6 +109,8 @@ pub fn server_address(hostname: &str, port: Option<u16>) -> String {
 /// println!("Articles: {} to {}", group.low, group.high);
 /// # Ok::<(), mlh_archiver::errors::Error>(())
 /// ```
+
+#[cfg_attr(feature = "otel", tracing::instrument)]
 pub fn get_group_info(
     nntp_stream: &mut NNTPStream,
     group_name: &str,
@@ -140,6 +144,8 @@ pub fn get_group_info(
 /// println!("Available groups: {}", groups.len());
 /// # Ok::<(), mlh_archiver::errors::Error>(())
 /// ```
+
+#[cfg_attr(feature = "otel", tracing::instrument)]
 pub fn retrieve_lists_with_connection(
     hostname: &str,
     port: Option<u16>,
@@ -172,6 +178,8 @@ pub fn retrieve_lists_with_connection(
 ///
 /// * `Ok(Vec<(String, nntp::NewsGroup)>)` - Pair of group name and info
 /// * `Err(...)` - Connection or protocol error
+
+#[cfg_attr(feature = "otel", tracing::instrument)]
 pub fn retrieve_groups_info(
     hostname: &str,
     port: Option<u16>,

--- a/mlh_archiver/src/nntp_source/nntp_utils.rs
+++ b/mlh_archiver/src/nntp_source/nntp_utils.rs
@@ -37,8 +37,7 @@ use nntp::NNTPStream;
 /// stream.quit()?;
 /// # Ok::<(), mlh_archiver::errors::Error>(())
 /// ```
-
-#[cfg_attr(feature = "otel", tracing::instrument)]
+#[cfg_attr(feature = "otel", tracing::instrument(skip(password)))]
 pub fn connect_to_nntp_server(
     hostname: &str,
     port: Option<u16>,
@@ -109,8 +108,7 @@ pub fn server_address(hostname: &str, port: Option<u16>) -> String {
 /// println!("Articles: {} to {}", group.low, group.high);
 /// # Ok::<(), mlh_archiver::errors::Error>(())
 /// ```
-
-#[cfg_attr(feature = "otel", tracing::instrument)]
+#[cfg_attr(feature = "otel", tracing::instrument(skip(nntp_stream)))]
 pub fn get_group_info(
     nntp_stream: &mut NNTPStream,
     group_name: &str,
@@ -144,8 +142,7 @@ pub fn get_group_info(
 /// println!("Available groups: {}", groups.len());
 /// # Ok::<(), mlh_archiver::errors::Error>(())
 /// ```
-
-#[cfg_attr(feature = "otel", tracing::instrument)]
+#[cfg_attr(feature = "otel", tracing::instrument(skip(password)))]
 pub fn retrieve_lists_with_connection(
     hostname: &str,
     port: Option<u16>,
@@ -178,8 +175,7 @@ pub fn retrieve_lists_with_connection(
 ///
 /// * `Ok(Vec<(String, nntp::NewsGroup)>)` - Pair of group name and info
 /// * `Err(...)` - Connection or protocol error
-
-#[cfg_attr(feature = "otel", tracing::instrument)]
+#[cfg_attr(feature = "otel", tracing::instrument(skip(password)))]
 pub fn retrieve_groups_info(
     hostname: &str,
     port: Option<u16>,

--- a/mlh_archiver/src/nntp_source/nntp_utils.rs
+++ b/mlh_archiver/src/nntp_source/nntp_utils.rs
@@ -6,7 +6,7 @@
 //! # Functions
 //!
 //! - [`connect_to_nntp_server`] - Establish connection to NNTP server
-//! - [`get_group_info`] - Retrieve group information (article range)
+//! - [`get_group_info`] - Retrieve group information (email range)
 //! - [`retrieve_lists_with_connection`] - Get all available groups
 
 use crate::errors;
@@ -82,7 +82,7 @@ pub fn server_address(hostname: &str, port: Option<u16>) -> String {
     }
 }
 
-/// Retrieves information about a newsgroup including article range.
+/// Retrieves information about a newsgroup including email range.
 ///
 /// This function queries the NNTP server for group statistics including
 /// the low and high article numbers, which can be used to determine
@@ -95,7 +95,7 @@ pub fn server_address(hostname: &str, port: Option<u16>) -> String {
 ///
 /// # Returns
 ///
-/// * `Ok(NewsGroup)` - Group information with article range
+/// * `Ok(NewsGroup)` - Group information with email range
 /// * `Err(...)` - NNTP protocol error
 ///
 /// # Example
@@ -163,7 +163,7 @@ pub fn retrieve_lists_with_connection(
 /// Retrieves group information for multiple groups in a single call.
 ///
 /// This function connects to the server, queries info for each group,
-/// and returns the results. Useful for previewing article ranges.
+/// and returns the results. Useful for previewing email ranges.
 ///
 /// # Arguments
 ///

--- a/mlh_archiver/src/nntp_source/nntp_worker.rs
+++ b/mlh_archiver/src/nntp_source/nntp_worker.rs
@@ -38,6 +38,7 @@ use std::time::Duration;
 /// Progress is managed by [`ArchiveWriter`]:
 /// - `__progress.yaml` - Last successfully fetched article ID
 /// - `__errors.csv` - Log of unavailable articles
+#[derive(std::fmt::Debug)]
 pub struct NNTPWorker {
     id: u8,
     nntp_config: NntpConfig,
@@ -108,6 +109,7 @@ impl NNTPWorker {
 }
 
 impl Worker for NNTPWorker {
+    #[cfg_attr(feature = "otel", tracing::instrument)]
     fn consumme_list(
         self: Box<Self>,
         receiver: crossbeam_channel::Receiver<String>,
@@ -233,6 +235,7 @@ impl Worker for NNTPWorker {
         }
     }
 
+    #[cfg_attr(feature = "otel", tracing::instrument)]
     fn read_email_by_index(&self, list_name: String, email_index: usize) -> crate::Result<()> {
         let writer = ArchiveWriter::new(
             Path::new(&self.base_output_path),
@@ -280,6 +283,8 @@ impl NNTPWorker {
     /// - Creates/updates `__progress.yaml` YAML file via writer
     /// - Writes fetched emails as `.eml` files via writer
     /// - Logs unavailable articles to `__errors.csv` file via writer
+
+    #[cfg_attr(feature = "otel", tracing::instrument)]
     pub fn handle_group(
         &self,
         list_name: String,
@@ -367,7 +372,9 @@ impl NNTPWorker {
     /// # Shutdown Behavior
     ///
     /// If shutdown is requested during fetching, returns the count of
-    /// emails fetched so far without error.
+    /// emails fetched so far without error
+
+    #[cfg_attr(feature = "otel", tracing::instrument)]
     fn read_new_mails(
         &self,
         list_name: String,

--- a/mlh_archiver/src/nntp_source/nntp_worker.rs
+++ b/mlh_archiver/src/nntp_source/nntp_worker.rs
@@ -38,7 +38,6 @@ use std::time::Duration;
 /// Progress is managed by [`ArchiveWriter`]:
 /// - `__progress.yaml` - Last successfully fetched article ID
 /// - `__errors.csv` - Log of unavailable articles
-#[derive(std::fmt::Debug)]
 pub struct NNTPWorker {
     id: u8,
     nntp_config: NntpConfig,
@@ -109,7 +108,6 @@ impl NNTPWorker {
 }
 
 impl Worker for NNTPWorker {
-    #[cfg_attr(feature = "otel", tracing::instrument)]
     fn consumme_list(
         self: Box<Self>,
         receiver: crossbeam_channel::Receiver<String>,
@@ -168,14 +166,7 @@ impl Worker for NNTPWorker {
                 }
             };
 
-            // create ArchiveWriter instance for the new list
-            let writer = ArchiveWriter::new(
-                Path::new(&self.base_output_path),
-                &list_name,
-                RunModeConfig::NNTP(self.nntp_config.clone()),
-            );
-
-            match self.handle_group(list_name.clone(), &writer) {
+            match self.handle_group(list_name.clone()) {
                 Ok(return_status) => {
                     log::info!("W{}: completed a task with: {return_status}", self.id);
                 }
@@ -235,7 +226,7 @@ impl Worker for NNTPWorker {
         }
     }
 
-    #[cfg_attr(feature = "otel", tracing::instrument)]
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self)))]
     fn read_email_by_index(&self, list_name: String, email_index: usize) -> crate::Result<()> {
         let writer = ArchiveWriter::new(
             Path::new(&self.base_output_path),
@@ -283,13 +274,15 @@ impl NNTPWorker {
     /// - Creates/updates `__progress.yaml` YAML file via writer
     /// - Writes fetched emails as `.eml` files via writer
     /// - Logs unavailable articles to `__errors.csv` file via writer
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self)))]
+    pub fn handle_group(&self, list_name: String) -> nntp::Result<NNTPWorkerGroupResult> {
+        // create ArchiveWriter instance for the new list
+        let writer = ArchiveWriter::new(
+            Path::new(&self.base_output_path),
+            &list_name,
+            RunModeConfig::NNTP(self.nntp_config.clone()),
+        );
 
-    #[cfg_attr(feature = "otel", tracing::instrument)]
-    pub fn handle_group(
-        &self,
-        list_name: String,
-        writer: &ArchiveWriter,
-    ) -> nntp::Result<NNTPWorkerGroupResult> {
         let last_article_number = writer
             .last_processed_id()
             .unwrap_or("0".to_string())
@@ -329,7 +322,7 @@ impl NNTPWorker {
                 list_name.clone(),
                 last_article_number.max(low),
                 high,
-                writer,
+                &writer,
             ) {
                 Ok(num_emails_read) => {
                     return Ok(NNTPWorkerGroupResult::Ok(list_name, num_emails_read));
@@ -373,8 +366,7 @@ impl NNTPWorker {
     ///
     /// If shutdown is requested during fetching, returns the count of
     /// emails fetched so far without error
-
-    #[cfg_attr(feature = "otel", tracing::instrument)]
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, writer)))]
     fn read_new_mails(
         &self,
         list_name: String,
@@ -421,6 +413,7 @@ impl NNTPWorker {
         Ok(num_emails_read)
     }
 
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self)))]
     fn get_raw_article_by_number_retryable(
         &self,
         mail_num: isize,

--- a/mlh_archiver/src/otel.rs
+++ b/mlh_archiver/src/otel.rs
@@ -1,0 +1,113 @@
+use opentelemetry::{KeyValue, global, trace::TracerProvider as _};
+use opentelemetry_otlp::WithExportConfig;
+use opentelemetry_sdk::{
+    Resource,
+    metrics::{MeterProviderBuilder, PeriodicReader, SdkMeterProvider},
+    trace::{RandomIdGenerator, Sampler, SdkTracerProvider},
+};
+use opentelemetry_semantic_conventions::{
+    SCHEMA_URL,
+    attribute::SERVICE_VERSION,
+};
+use tracing_core::Level;
+use tracing_opentelemetry::{MetricsLayer, OpenTelemetryLayer};
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+fn otlp_endpoint() -> String {
+    std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT")
+        .unwrap_or_else(|_| "http://localhost:4318".to_string())
+}
+
+fn resource() -> Resource {
+    Resource::builder()
+        .with_service_name(env!("CARGO_PKG_NAME"))
+        .with_schema_url(
+            [
+                KeyValue::new(SERVICE_VERSION, env!("CARGO_PKG_VERSION")),
+                KeyValue::new("deployment.environment", "develop"),
+            ],
+            SCHEMA_URL,
+        )
+        .build()
+}
+
+fn init_meter_provider() -> SdkMeterProvider {
+    let exporter = opentelemetry_otlp::MetricExporter::builder()
+        .with_http()
+        .with_endpoint(format!("{}/v1/metrics", otlp_endpoint()))
+        .with_temporality(opentelemetry_sdk::metrics::Temporality::default())
+        .build()
+        .unwrap();
+
+    let reader = PeriodicReader::builder(exporter)
+        .with_interval(std::time::Duration::from_secs(30))
+        .build();
+
+    let stdout_reader =
+        PeriodicReader::builder(opentelemetry_stdout::MetricExporter::default()).build();
+
+    let meter_provider = MeterProviderBuilder::default()
+        .with_resource(resource())
+        .with_reader(reader)
+        .with_reader(stdout_reader)
+        .build();
+
+    global::set_meter_provider(meter_provider.clone());
+
+    meter_provider
+}
+
+fn init_tracer_provider() -> SdkTracerProvider {
+    let exporter = opentelemetry_otlp::SpanExporter::builder()
+        .with_http()
+        .with_endpoint(format!("{}/v1/traces", otlp_endpoint()))
+        .build()
+        .unwrap();
+
+    // SimpleSpanProcessor exports synchronously on span end — no async runtime needed
+    SdkTracerProvider::builder()
+        .with_sampler(Sampler::ParentBased(Box::new(Sampler::TraceIdRatioBased(
+            1.0,
+        ))))
+        .with_id_generator(RandomIdGenerator::default())
+        .with_resource(resource())
+        .with_simple_exporter(exporter)
+        .build()
+}
+
+pub fn init_tracing_subscriber() -> OtelGuard {
+    let tracer_provider = init_tracer_provider();
+    let meter_provider = init_meter_provider();
+
+    let tracer = tracer_provider.tracer("tracing-otel-subscriber");
+
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::filter::LevelFilter::from_level(
+            Level::INFO,
+        ))
+        .with(tracing_subscriber::fmt::layer())
+        .with(MetricsLayer::new(meter_provider.clone()))
+        .with(OpenTelemetryLayer::new(tracer))
+        .init();
+
+    OtelGuard {
+        tracer_provider,
+        meter_provider,
+    }
+}
+
+pub struct OtelGuard {
+    tracer_provider: SdkTracerProvider,
+    meter_provider: SdkMeterProvider,
+}
+
+impl Drop for OtelGuard {
+    fn drop(&mut self) {
+        if let Err(err) = self.tracer_provider.shutdown() {
+            eprintln!("{err:?}");
+        }
+        if let Err(err) = self.meter_provider.shutdown() {
+            eprintln!("{err:?}");
+        }
+    }
+}

--- a/mlh_archiver/src/otel.rs
+++ b/mlh_archiver/src/otel.rs
@@ -5,10 +5,7 @@ use opentelemetry_sdk::{
     metrics::{MeterProviderBuilder, PeriodicReader, SdkMeterProvider},
     trace::{RandomIdGenerator, Sampler, SdkTracerProvider},
 };
-use opentelemetry_semantic_conventions::{
-    SCHEMA_URL,
-    attribute::SERVICE_VERSION,
-};
+use opentelemetry_semantic_conventions::{SCHEMA_URL, attribute::SERVICE_VERSION};
 use tracing_core::Level;
 use tracing_opentelemetry::{MetricsLayer, OpenTelemetryLayer};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};

--- a/mlh_archiver/src/public_inbox_source/pi_config.rs
+++ b/mlh_archiver/src/public_inbox_source/pi_config.rs
@@ -4,7 +4,7 @@ use crate::errors::ConfigError;
 ///
 /// This struct holds the configuration needed to connect to and process a public inbox.
 /// It includes the import directory, origin, and optional settings for grokmirror,
-/// public inbox config, and article range.
+/// public inbox config, and email range.
 #[derive(Debug, serde::Deserialize, serde::Serialize, PartialEq, Eq, Clone, Default)]
 pub struct PIConfig {
     /// (optional) if specified, will use grokmirror to identify the lists available
@@ -20,7 +20,7 @@ pub struct PIConfig {
     /// (optional). Read a specific range of articles from the first list provided.
     /// Comma separated values, or dash separated ranges, like low-high
     /// Article numbers are 1-indexed.
-    pub article_range: Option<String>,
+    pub email_range: Option<String>,
 }
 
 impl PIConfig {
@@ -65,7 +65,7 @@ impl PIConfig {
             return Err(ConfigError::MissingOrigin);
         }
 
-        // TODO: validate article_range format using parse_sequence
+        // TODO: validate email_range format using parse_sequence
         // For now, just ignore
 
         Ok(())

--- a/mlh_archiver/src/public_inbox_source/pi_lister.rs
+++ b/mlh_archiver/src/public_inbox_source/pi_lister.rs
@@ -29,6 +29,8 @@ use std::path::PathBuf;
 /// };
 /// let lists = retrieve_lists(config).expect("Failed to retrieve lists");
 /// ```
+
+#[cfg_attr(feature = "otel", tracing::instrument)]
 pub fn retrieve_lists(pi_config: PIConfig) -> crate::Result<Vec<String>> {
     // Validate the configuration before proceeding.
     pi_config.validate()?;

--- a/mlh_archiver/src/public_inbox_source/pi_lister.rs
+++ b/mlh_archiver/src/public_inbox_source/pi_lister.rs
@@ -29,7 +29,6 @@ use std::path::PathBuf;
 /// };
 /// let lists = retrieve_lists(config).expect("Failed to retrieve lists");
 /// ```
-
 #[cfg_attr(feature = "otel", tracing::instrument)]
 pub fn retrieve_lists(pi_config: PIConfig) -> crate::Result<Vec<String>> {
     // Validate the configuration before proceeding.

--- a/mlh_archiver/src/public_inbox_source/pi_utils.rs
+++ b/mlh_archiver/src/public_inbox_source/pi_utils.rs
@@ -54,6 +54,8 @@ impl fmt::Display for PublicInbox {
 ///
 /// * `Ok(Vec<PublicInbox>)` - A vector of discovered public inboxes, sorted by name
 /// * `Err` - If an I/O error occurs while reading the directory
+
+#[cfg_attr(feature = "otel", tracing::instrument)]
 pub fn find_public_inboxes(base_dir: &Path) -> errors::Result<Vec<PublicInbox>> {
     let mut inboxes = Vec::new();
 
@@ -92,6 +94,7 @@ pub fn find_public_inboxes(base_dir: &Path) -> errors::Result<Vec<PublicInbox>> 
 ///
 /// * `true` — this function no longer gates repo acceptance; it only provides
 ///   diagnostics. Use `is_git2_openable` to determine usability.
+#[cfg_attr(feature = "otel", tracing::instrument)]
 fn log_broken_alternates(dir: &Path) {
     let alternates_path = dir.join("objects/info/alternates");
     if !alternates_path.is_file() {
@@ -137,6 +140,8 @@ fn is_git2_openable(dir: &Path) -> bool {
 ///
 /// * `true` if the directory appears to be a git repository
 /// * `false` otherwise
+
+#[cfg_attr(feature = "otel", tracing::instrument)]
 fn is_git_repo(dir: &Path) -> bool {
     dir.join("HEAD").is_file() && dir.join("objects").is_dir()
 }
@@ -155,6 +160,8 @@ fn is_git_repo(dir: &Path) -> bool {
 ///
 /// * `true` if the repository has a master ref
 /// * `false` otherwise
+
+#[cfg_attr(feature = "otel", tracing::instrument)]
 fn has_master_ref(dir: &Path) -> bool {
     if dir.join("refs/heads/master").is_file() {
         return true;
@@ -185,6 +192,8 @@ fn has_master_ref(dir: &Path) -> bool {
 /// * `Ok(Some(PathBuf))` - Path to an epoch repository with master ref
 /// * `Ok(None)` - No epoch repository with master ref was found
 /// * `Err` - If an I/O error occurs while reading the directory
+
+#[cfg_attr(feature = "otel", tracing::instrument)]
 fn find_epoch_repo_with_master(git_dir: &Path) -> crate::Result<Option<PathBuf>> {
     for entry in std::fs::read_dir(git_dir)? {
         let entry = entry?;
@@ -220,6 +229,8 @@ fn find_epoch_repo_with_master(git_dir: &Path) -> crate::Result<Option<PathBuf>>
 ///
 /// * `true` if the repository has objects
 /// * `false` if the objects directory is empty or doesn't exist
+
+#[cfg_attr(feature = "otel", tracing::instrument)]
 fn has_objects(dir: &Path) -> bool {
     let objects_dir = dir.join("objects");
     if !objects_dir.is_dir() {
@@ -248,6 +259,7 @@ fn has_objects(dir: &Path) -> bool {
 /// * `Ok(Some(PublicInbox))` - Information about the detected public inbox
 /// * `Ok(None)` - The directory does not appear to be a public inbox
 /// * `Err` - If an I/O error occurs while reading files
+#[cfg_attr(feature = "otel", tracing::instrument)]
 pub fn detect_inbox(dir: &Path) -> crate::Result<Option<PublicInbox>> {
     let name = dir
         .file_name()
@@ -389,6 +401,7 @@ pub fn detect_inbox(dir: &Path) -> crate::Result<Option<PublicInbox>> {
 ///
 /// * `Ok(git2::Oid)` - The object ID of the commit at the specified position
 /// * `Err` - If the position is out of bounds or an error occurs during revision walking
+#[cfg_attr(feature = "otel", tracing::instrument(skip(repo)))]
 pub fn get_commit_at_position(
     repo: &git2::Repository,
     position: usize,
@@ -424,6 +437,8 @@ pub fn get_commit_at_position(
 ///
 /// * `Ok((String, String))` - A tuple of (commit_hash, raw_email_content)
 /// * `Err` - If no 'm' blob is found in the commit tree or an error occurs
+
+#[cfg_attr(feature = "otel", tracing::instrument(skip(repo)))]
 pub fn extract_email_from_commit(
     repo: &git2::Repository,
     commit: &git2::Commit,
@@ -462,6 +477,7 @@ pub fn extract_email_from_commit(
 ///
 /// * `Ok(String)` - The raw content of the blob as a UTF-8 string
 /// * `Err` - If the blob cannot be found or read
+#[cfg_attr(feature = "otel", tracing::instrument(skip(repo)))]
 pub fn read_by_blob_id(repo: &git2::Repository, blob_oid: git2::Oid) -> crate::Result<String> {
     let blob = repo.find_blob(blob_oid)?;
     let raw_email = String::from_utf8_lossy(blob.content()).to_string();
@@ -481,6 +497,7 @@ pub fn read_by_blob_id(repo: &git2::Repository, blob_oid: git2::Oid) -> crate::R
 ///
 /// * `Ok(usize)` - The total number of commits in the repository
 /// * `Err` - If an error occurs during revision walking
+#[cfg_attr(feature = "otel", tracing::instrument(skip(repo)))]
 pub fn count_commits(repo: &git2::Repository) -> crate::Result<usize> {
     let head_id = repo
         .refname_to_id("refs/heads/master")
@@ -512,6 +529,8 @@ pub fn count_commits(repo: &git2::Repository) -> crate::Result<usize> {
 /// # Returns
 ///
 /// * `String` - The formatted email ID
+
+#[cfg_attr(feature = "otel", tracing::instrument)]
 pub fn format_email_id(email_num: usize, epoch_name: &str, commit_sha: &str) -> String {
     let padded = format!("{:010}", email_num);
     format!("{}-e{}-{}", padded, epoch_name, commit_sha)
@@ -546,6 +565,8 @@ pub struct ParsedEmailId {
 ///
 /// * `Some(ParsedEmailId)` - The parsed components if the format matches
 /// * `None` - If the format doesn't match the expected pattern
+
+#[cfg_attr(feature = "otel", tracing::instrument)]
 pub fn parse_email_id(id: &str) -> Option<ParsedEmailId> {
     let parts: Vec<&str> = id.splitn(3, '-').collect();
     if parts.len() != 3 {
@@ -583,6 +604,7 @@ pub fn parse_email_id(id: &str) -> Option<ParsedEmailId> {
 ///
 /// * `Ok(Vec<git2::Oid>)` - A vector of commit object IDs, newest first
 /// * `Err` - If an error occurs during revision walking
+#[cfg_attr(feature = "otel", tracing::instrument(skip(repo)))]
 pub fn collect_all_commits(repo: &git2::Repository) -> crate::Result<Vec<git2::Oid>> {
     let head_id = repo
         .refname_to_id("refs/heads/master")

--- a/mlh_archiver/src/public_inbox_source/pi_utils.rs
+++ b/mlh_archiver/src/public_inbox_source/pi_utils.rs
@@ -54,8 +54,6 @@ impl fmt::Display for PublicInbox {
 ///
 /// * `Ok(Vec<PublicInbox>)` - A vector of discovered public inboxes, sorted by name
 /// * `Err` - If an I/O error occurs while reading the directory
-
-#[cfg_attr(feature = "otel", tracing::instrument)]
 pub fn find_public_inboxes(base_dir: &Path) -> errors::Result<Vec<PublicInbox>> {
     let mut inboxes = Vec::new();
 
@@ -94,7 +92,6 @@ pub fn find_public_inboxes(base_dir: &Path) -> errors::Result<Vec<PublicInbox>> 
 ///
 /// * `true` — this function no longer gates repo acceptance; it only provides
 ///   diagnostics. Use `is_git2_openable` to determine usability.
-#[cfg_attr(feature = "otel", tracing::instrument)]
 fn log_broken_alternates(dir: &Path) {
     let alternates_path = dir.join("objects/info/alternates");
     if !alternates_path.is_file() {
@@ -140,8 +137,6 @@ fn is_git2_openable(dir: &Path) -> bool {
 ///
 /// * `true` if the directory appears to be a git repository
 /// * `false` otherwise
-
-#[cfg_attr(feature = "otel", tracing::instrument)]
 fn is_git_repo(dir: &Path) -> bool {
     dir.join("HEAD").is_file() && dir.join("objects").is_dir()
 }
@@ -160,8 +155,6 @@ fn is_git_repo(dir: &Path) -> bool {
 ///
 /// * `true` if the repository has a master ref
 /// * `false` otherwise
-
-#[cfg_attr(feature = "otel", tracing::instrument)]
 fn has_master_ref(dir: &Path) -> bool {
     if dir.join("refs/heads/master").is_file() {
         return true;
@@ -192,8 +185,6 @@ fn has_master_ref(dir: &Path) -> bool {
 /// * `Ok(Some(PathBuf))` - Path to an epoch repository with master ref
 /// * `Ok(None)` - No epoch repository with master ref was found
 /// * `Err` - If an I/O error occurs while reading the directory
-
-#[cfg_attr(feature = "otel", tracing::instrument)]
 fn find_epoch_repo_with_master(git_dir: &Path) -> crate::Result<Option<PathBuf>> {
     for entry in std::fs::read_dir(git_dir)? {
         let entry = entry?;
@@ -229,8 +220,6 @@ fn find_epoch_repo_with_master(git_dir: &Path) -> crate::Result<Option<PathBuf>>
 ///
 /// * `true` if the repository has objects
 /// * `false` if the objects directory is empty or doesn't exist
-
-#[cfg_attr(feature = "otel", tracing::instrument)]
 fn has_objects(dir: &Path) -> bool {
     let objects_dir = dir.join("objects");
     if !objects_dir.is_dir() {
@@ -401,7 +390,6 @@ pub fn detect_inbox(dir: &Path) -> crate::Result<Option<PublicInbox>> {
 ///
 /// * `Ok(git2::Oid)` - The object ID of the commit at the specified position
 /// * `Err` - If the position is out of bounds or an error occurs during revision walking
-#[cfg_attr(feature = "otel", tracing::instrument(skip(repo)))]
 pub fn get_commit_at_position(
     repo: &git2::Repository,
     position: usize,
@@ -437,8 +425,6 @@ pub fn get_commit_at_position(
 ///
 /// * `Ok((String, String))` - A tuple of (commit_hash, raw_email_content)
 /// * `Err` - If no 'm' blob is found in the commit tree or an error occurs
-
-#[cfg_attr(feature = "otel", tracing::instrument(skip(repo)))]
 pub fn extract_email_from_commit(
     repo: &git2::Repository,
     commit: &git2::Commit,
@@ -477,7 +463,6 @@ pub fn extract_email_from_commit(
 ///
 /// * `Ok(String)` - The raw content of the blob as a UTF-8 string
 /// * `Err` - If the blob cannot be found or read
-#[cfg_attr(feature = "otel", tracing::instrument(skip(repo)))]
 pub fn read_by_blob_id(repo: &git2::Repository, blob_oid: git2::Oid) -> crate::Result<String> {
     let blob = repo.find_blob(blob_oid)?;
     let raw_email = String::from_utf8_lossy(blob.content()).to_string();
@@ -529,8 +514,6 @@ pub fn count_commits(repo: &git2::Repository) -> crate::Result<usize> {
 /// # Returns
 ///
 /// * `String` - The formatted email ID
-
-#[cfg_attr(feature = "otel", tracing::instrument)]
 pub fn format_email_id(email_num: usize, epoch_name: &str, commit_sha: &str) -> String {
     let padded = format!("{:010}", email_num);
     format!("{}-e{}-{}", padded, epoch_name, commit_sha)
@@ -565,8 +548,6 @@ pub struct ParsedEmailId {
 ///
 /// * `Some(ParsedEmailId)` - The parsed components if the format matches
 /// * `None` - If the format doesn't match the expected pattern
-
-#[cfg_attr(feature = "otel", tracing::instrument)]
 pub fn parse_email_id(id: &str) -> Option<ParsedEmailId> {
     let parts: Vec<&str> = id.splitn(3, '-').collect();
     if parts.len() != 3 {

--- a/mlh_archiver/src/public_inbox_source/pi_worker.rs
+++ b/mlh_archiver/src/public_inbox_source/pi_worker.rs
@@ -28,6 +28,7 @@ struct ProcessEpochResult {
 /// This struct represents a worker that consumes inbox names from a channel and processes
 /// the emails contained within those inboxes. It handles both V1 and V2 public inbox
 /// formats, supports resuming from a specific email, and can filter emails by article range.
+#[derive(std::fmt::Debug)]
 pub struct PIWorker {
     /// Unique identifier for this worker instance
     id: u8,
@@ -83,6 +84,8 @@ impl Worker for PIWorker {
     ///
     /// * `Ok(())` - If the worker exits cleanly (shutdown requested or channel closed)
     /// * `Err` - If an error occurs while processing an inbox (logged but doesn't stop the worker)
+
+    #[cfg_attr(feature = "otel", tracing::instrument)]
     fn consumme_list(
         self: Box<Self>,
         receiver: crossbeam_channel::Receiver<String>,
@@ -132,6 +135,8 @@ impl Worker for PIWorker {
     ///
     /// * `Ok(())` - If the email was successfully retrieved and archived
     /// * `Err` - If the inbox is not found, the index is out of bounds, or an error occurs
+
+    #[cfg_attr(feature = "otel", tracing::instrument)]
     fn read_email_by_index(&self, list_name: String, email_index: usize) -> crate::Result<()> {
         let writer = ArchiveWriter::new(
             Path::new(&self.base_output_path),
@@ -218,6 +223,8 @@ impl PIWorker {
     ///
     /// * `Ok(usize)` - The number of emails successfully processed
     /// * `Err` - If the inbox is not found or an error occurs during processing
+
+    #[cfg_attr(feature = "otel", tracing::instrument)]
     fn process_inbox(&self, list_name: &str) -> crate::Result<usize> {
         log::info!(
             "W{}: Starting processing emails from {}",
@@ -362,6 +369,7 @@ impl PIWorker {
     ///
     /// * `Ok(ProcessEpochResult)` - Results including emails processed and updated counters
     /// * `Err` - If an error occurs during processing
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(repo)))]
     fn process_epoch(
         &self,
         repo: &git2::Repository,

--- a/mlh_archiver/src/public_inbox_source/pi_worker.rs
+++ b/mlh_archiver/src/public_inbox_source/pi_worker.rs
@@ -27,7 +27,7 @@ struct ProcessEpochResult {
 ///
 /// This struct represents a worker that consumes inbox names frpodmanhannel and processes
 /// the emails contained within those inboxes. It handles both V1 and V2 public inbox
-/// formats, supports resuming from a specific email, and can filter emails by article range.
+/// formats, supports resuming from a specific email, and can filter emails by email range.
 #[derive(std::fmt::Debug)]
 pub struct PIWorker {
     /// Unique identifier for this worker instance
@@ -133,7 +133,6 @@ impl Worker for PIWorker {
     ///
     /// * `Ok(())` - If the email was successfully retrieved and archived
     /// * `Err` - If the inbox is not found, the index is out of bounds, or an error occurs
-
     #[cfg_attr(feature = "otel", tracing::instrument(skip(self)))]
     fn read_email_by_index(&self, list_name: String, email_index: usize) -> crate::Result<()> {
         let writer = ArchiveWriter::new(
@@ -210,7 +209,7 @@ impl PIWorker {
     /// all commits in the inbox (across all epochs for V2 inboxes), extracts the
     /// email content from each commit, and archives it using the ArchiveWriter.
     /// It supports resuming from a specific email based on progress tracking
-    /// and filtering by article range.
+    /// and filtering by email range.
     ///
     /// # Arguments
     ///
@@ -221,7 +220,6 @@ impl PIWorker {
     ///
     /// * `Ok(usize)` - The number of emails successfully processed
     /// * `Err` - If the inbox is not found or an error occurs during processing
-
     #[cfg_attr(feature = "otel", tracing::instrument(skip(self)))]
     fn process_inbox(&self, list_name: &str) -> crate::Result<usize> {
         log::info!(
@@ -269,10 +267,10 @@ impl PIWorker {
             global_position = parsed.email_num;
         }
 
-        // Parse article range if configured
-        let article_range_positions: Option<std::collections::HashSet<usize>> = match &self
+        // Parse email range if configured
+        let email_range_positions: Option<std::collections::HashSet<usize>> = match &self
             .pi_config
-            .article_range
+            .email_range
         {
             Some(range_str) => {
                 let parsed_range =
@@ -326,7 +324,7 @@ impl PIWorker {
                 &repo,
                 epoch,
                 &writer,
-                &article_range_positions,
+                &email_range_positions,
                 &skip_until_sha,
                 global_position,
             )?;
@@ -350,7 +348,7 @@ impl PIWorker {
     /// Process a single epoch, streaming commits and archiving emails.
     ///
     /// This function handles the core logic of processing one epoch of a public inbox,
-    /// including commit iteration, article range filtering, resume-from-SHA logic,
+    /// including commit iteration, email range filtering, resume-from-SHA logic,
     /// and email extraction and archiving.
     ///
     /// # Arguments
@@ -358,7 +356,7 @@ impl PIWorker {
     /// * `repo` - The git repository for this epoch
     /// * `epoch` - Information about the epoch being processed
     /// * `writer` - Archive writer for storing processed emails
-    /// * `article_range_positions` - Optional set of positions to filter by article range
+    /// * `email_range_positions` - Optional set of positions to filter by email range
     /// * `skip_until_sha` - Optional short SHA to skip commits until found
     /// * `global_position` - Current global email position across all epochs
     /// * `shutdown_flag` - Flag to check for shutdown requests
@@ -373,7 +371,7 @@ impl PIWorker {
         repo: &git2::Repository,
         epoch: &EpochRepo,
         writer: &ArchiveWriter,
-        article_range_positions: &Option<HashSet<usize>>,
+        email_range_positions: &Option<HashSet<usize>>,
         skip_until_sha: &Option<String>,
         global_position: usize,
     ) -> crate::Result<ProcessEpochResult> {
@@ -499,7 +497,7 @@ impl PIWorker {
 
             let current_global_position = global_position + commit_count;
 
-            if let Some(positions) = article_range_positions
+            if let Some(positions) = email_range_positions
                 && !positions.contains(&current_global_position)
             {
                 commit_count += 1;

--- a/mlh_archiver/src/public_inbox_source/pi_worker.rs
+++ b/mlh_archiver/src/public_inbox_source/pi_worker.rs
@@ -25,7 +25,7 @@ struct ProcessEpochResult {
 
 /// A worker that processes public inbox email archives.
 ///
-/// This struct represents a worker that consumes inbox names from a channel and processes
+/// This struct represents a worker that consumes inbox names frpodmanhannel and processes
 /// the emails contained within those inboxes. It handles both V1 and V2 public inbox
 /// formats, supports resuming from a specific email, and can filter emails by article range.
 #[derive(std::fmt::Debug)]
@@ -84,8 +84,6 @@ impl Worker for PIWorker {
     ///
     /// * `Ok(())` - If the worker exits cleanly (shutdown requested or channel closed)
     /// * `Err` - If an error occurs while processing an inbox (logged but doesn't stop the worker)
-
-    #[cfg_attr(feature = "otel", tracing::instrument)]
     fn consumme_list(
         self: Box<Self>,
         receiver: crossbeam_channel::Receiver<String>,
@@ -136,7 +134,7 @@ impl Worker for PIWorker {
     /// * `Ok(())` - If the email was successfully retrieved and archived
     /// * `Err` - If the inbox is not found, the index is out of bounds, or an error occurs
 
-    #[cfg_attr(feature = "otel", tracing::instrument)]
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self)))]
     fn read_email_by_index(&self, list_name: String, email_index: usize) -> crate::Result<()> {
         let writer = ArchiveWriter::new(
             Path::new(&self.base_output_path),
@@ -224,7 +222,7 @@ impl PIWorker {
     /// * `Ok(usize)` - The number of emails successfully processed
     /// * `Err` - If the inbox is not found or an error occurs during processing
 
-    #[cfg_attr(feature = "otel", tracing::instrument)]
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self)))]
     fn process_inbox(&self, list_name: &str) -> crate::Result<usize> {
         log::info!(
             "W{}: Starting processing emails from {}",
@@ -369,7 +367,7 @@ impl PIWorker {
     ///
     /// * `Ok(ProcessEpochResult)` - Results including emails processed and updated counters
     /// * `Err` - If an error occurs during processing
-    #[cfg_attr(feature = "otel", tracing::instrument(skip(repo)))]
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(repo, writer, self)))]
     fn process_epoch(
         &self,
         repo: &git2::Repository,

--- a/mlh_archiver/src/scheduler.rs
+++ b/mlh_archiver/src/scheduler.rs
@@ -45,6 +45,7 @@ const CHANNEL_CAPACITY: usize = 10;
 /// 1. Signal handler sets the flag
 /// 2. Workers detect flag and exit gracefully
 /// 3. Producer threads detect closed channels and exit
+#[derive(std::fmt::Debug)]
 pub struct Scheduler<'a> {
     app_config: &'a AppConfig,
     loop_groups: bool,
@@ -113,6 +114,8 @@ impl<'a> Scheduler<'a> {
     ///
     /// * `Ok(())` on successful completion
     /// * `Err(...)` if any thread panics during join
+
+    #[cfg_attr(feature = "otel", tracing::instrument)]
     pub fn run(&mut self) -> crate::Result<()> {
         // Collect thread handles
         let mut handles = Vec::new();
@@ -203,6 +206,8 @@ impl<'a> Scheduler<'a> {
     /// # Returns
     ///
     /// Vector of thread join handles.
+
+    #[cfg_attr(feature = "otel", tracing::instrument)]
     fn spawn_workers_to_consumme_list(
         &self,
         workers: Vec<Box<dyn Worker>>,
@@ -244,6 +249,8 @@ impl<'a> Scheduler<'a> {
     /// # Returns
     ///
     /// Vector of thread join handles.
+
+    #[cfg_attr(feature = "otel", tracing::instrument)]
     fn spawn_worker_to_read_email_by_index(
         &self,
         workers: Vec<Box<dyn Worker>>,
@@ -310,6 +317,8 @@ impl<'a> Scheduler<'a> {
     ///
     /// The sender is dropped when the thread exits, signaling workers
     /// that no more tasks will arrive.
+
+    #[cfg_attr(feature = "otel", tracing::instrument)]
     fn spawn_producer_for_consume_list(
         sender: crossbeam_channel::Sender<String>,
         tasks: Vec<String>,
@@ -372,6 +381,7 @@ impl<'a> Scheduler<'a> {
     /// # Error Handling
     ///
     /// If range parsing fails, logs an error and drops the sender.
+    #[cfg_attr(feature = "otel", tracing::instrument)]
     fn spawn_producer_for_read_email_by_index(
         sender: crossbeam_channel::Sender<String>,
         tasks: Vec<String>,

--- a/mlh_archiver/src/scheduler.rs
+++ b/mlh_archiver/src/scheduler.rs
@@ -99,7 +99,7 @@ impl<'a> Scheduler<'a> {
     ///
     /// ## Range Mode
     ///
-    /// If `article_range` is configured:
+    /// If `email_range` is configured:
     /// - Workers use `read_email_by_index()` to fetch specific articles
     /// - Producer parses range text and sends (list, index) pairs
     ///

--- a/mlh_archiver/src/scheduler.rs
+++ b/mlh_archiver/src/scheduler.rs
@@ -45,7 +45,6 @@ const CHANNEL_CAPACITY: usize = 10;
 /// 1. Signal handler sets the flag
 /// 2. Workers detect flag and exit gracefully
 /// 3. Producer threads detect closed channels and exit
-#[derive(std::fmt::Debug)]
 pub struct Scheduler<'a> {
     app_config: &'a AppConfig,
     loop_groups: bool,
@@ -114,8 +113,6 @@ impl<'a> Scheduler<'a> {
     ///
     /// * `Ok(())` on successful completion
     /// * `Err(...)` if any thread panics during join
-
-    #[cfg_attr(feature = "otel", tracing::instrument)]
     pub fn run(&mut self) -> crate::Result<()> {
         // Collect thread handles
         let mut handles = Vec::new();
@@ -206,8 +203,6 @@ impl<'a> Scheduler<'a> {
     /// # Returns
     ///
     /// Vector of thread join handles.
-
-    #[cfg_attr(feature = "otel", tracing::instrument)]
     fn spawn_workers_to_consumme_list(
         &self,
         workers: Vec<Box<dyn Worker>>,
@@ -249,8 +244,6 @@ impl<'a> Scheduler<'a> {
     /// # Returns
     ///
     /// Vector of thread join handles.
-
-    #[cfg_attr(feature = "otel", tracing::instrument)]
     fn spawn_worker_to_read_email_by_index(
         &self,
         workers: Vec<Box<dyn Worker>>,
@@ -317,8 +310,6 @@ impl<'a> Scheduler<'a> {
     ///
     /// The sender is dropped when the thread exits, signaling workers
     /// that no more tasks will arrive.
-
-    #[cfg_attr(feature = "otel", tracing::instrument)]
     fn spawn_producer_for_consume_list(
         sender: crossbeam_channel::Sender<String>,
         tasks: Vec<String>,
@@ -381,7 +372,6 @@ impl<'a> Scheduler<'a> {
     /// # Error Handling
     ///
     /// If range parsing fails, logs an error and drops the sender.
-    #[cfg_attr(feature = "otel", tracing::instrument)]
     fn spawn_producer_for_read_email_by_index(
         sender: crossbeam_channel::Sender<String>,
         tasks: Vec<String>,

--- a/mlh_archiver/src/worker.rs
+++ b/mlh_archiver/src/worker.rs
@@ -53,7 +53,7 @@ use crate::public_inbox_source::pi_worker::PIWorker;
 /// 2. Moved to a thread via [`Scheduler`](crate::scheduler::Scheduler)
 /// 3. Runs until channel closes or shutdown is requested
 /// 4. Dropped when thread completes
-pub trait Worker: Send + std::fmt::Debug {
+pub trait Worker: Send {
     /// Processes mailing lists received via channel until completion or shutdown.
     ///
     /// This is the main entry point for email fetching. Implementations should:
@@ -124,7 +124,6 @@ pub trait Worker: Send + std::fmt::Debug {
 /// ```
 ///
 /// Each call to `receiver.recv()` delivers the task to exactly one worker.
-#[derive(std::fmt::Debug)]
 pub struct WorkerGroup {
     pub tasks: Vec<String>,
     pub workers: Vec<Box<dyn Worker>>,
@@ -148,7 +147,6 @@ pub struct WorkerGroup {
 ///
 /// The manager itself is not thread-safe. It is used only during
 /// initialization in the main thread before workers are moved to threads.
-#[derive(std::fmt::Debug)]
 pub struct WorkerManager {
     groups: Vec<WorkerGroup>,
 }
@@ -188,8 +186,6 @@ impl WorkerManager {
     /// Panics if `get_run_mode_config()` returns `None` for a run mode
     /// that was returned by `get_run_modes()`. This should not happen
     /// in normal operation.
-
-    #[cfg_attr(feature = "otel", tracing::instrument)]
     pub fn create_workers(
         &mut self,
         run_mode: RunMode,

--- a/mlh_archiver/src/worker.rs
+++ b/mlh_archiver/src/worker.rs
@@ -87,7 +87,7 @@ pub trait Worker: Send {
     ///
     /// This method is used for:
     /// - Re-fetching emails that previously failed
-    /// - Fetching specific articles via `article_range` configuration
+    /// - Fetching specific articles via `email_range` configuration
     ///
     /// # Arguments
     ///

--- a/mlh_archiver/src/worker.rs
+++ b/mlh_archiver/src/worker.rs
@@ -53,7 +53,7 @@ use crate::public_inbox_source::pi_worker::PIWorker;
 /// 2. Moved to a thread via [`Scheduler`](crate::scheduler::Scheduler)
 /// 3. Runs until channel closes or shutdown is requested
 /// 4. Dropped when thread completes
-pub trait Worker: Send {
+pub trait Worker: Send + std::fmt::Debug {
     /// Processes mailing lists received via channel until completion or shutdown.
     ///
     /// This is the main entry point for email fetching. Implementations should:
@@ -124,6 +124,7 @@ pub trait Worker: Send {
 /// ```
 ///
 /// Each call to `receiver.recv()` delivers the task to exactly one worker.
+#[derive(std::fmt::Debug)]
 pub struct WorkerGroup {
     pub tasks: Vec<String>,
     pub workers: Vec<Box<dyn Worker>>,
@@ -147,6 +148,7 @@ pub struct WorkerGroup {
 ///
 /// The manager itself is not thread-safe. It is used only during
 /// initialization in the main thread before workers are moved to threads.
+#[derive(std::fmt::Debug)]
 pub struct WorkerManager {
     groups: Vec<WorkerGroup>,
 }
@@ -186,6 +188,8 @@ impl WorkerManager {
     /// Panics if `get_run_mode_config()` returns `None` for a run mode
     /// that was returned by `get_run_modes()`. This should not happen
     /// in normal operation.
+
+    #[cfg_attr(feature = "otel", tracing::instrument)]
     pub fn create_workers(
         &mut self,
         run_mode: RunMode,

--- a/mlh_archiver/tests/test_config.rs
+++ b/mlh_archiver/tests/test_config.rs
@@ -374,11 +374,11 @@ fn test_get_read_lists_deduplicates() {
 }
 
 // =============================================================================
-// get_article_range() Tests
+// get_email_range() Tests
 // =============================================================================
 
 #[test]
-fn test_get_article_range_none() {
+fn test_get_email_range_none() {
     let config = AppConfig {
         nthreads: 1,
         output_dir: "./output".to_string(),
@@ -395,7 +395,7 @@ fn test_get_article_range_none() {
 }
 
 #[test]
-fn test_get_article_range_single_number() {
+fn test_get_email_range_single_number() {
     let config = AppConfig {
         nthreads: 1,
         output_dir: "./output".to_string(),
@@ -403,7 +403,7 @@ fn test_get_article_range_single_number() {
         nntp: Some(NntpConfig {
             hostname: "nntp.example.com".to_string(),
             port: Some(119),
-            article_range: Some("100".to_string()),
+            email_range: Some("100".to_string()),
             ..NntpConfig::default()
         }),
         ..Default::default()
@@ -418,14 +418,14 @@ fn test_get_article_range_single_number() {
 }
 
 #[test]
-fn test_get_article_range_multiple_numbers() {
+fn test_get_email_range_multiple_numbers() {
     let config = AppConfig {
         nthreads: 1,
         output_dir: "./output".to_string(),
         loop_groups: true,
         nntp: Some(NntpConfig {
             hostname: "nntp.example.com".to_string(),
-            article_range: Some("1,5,10".to_string()),
+            email_range: Some("1,5,10".to_string()),
             ..NntpConfig::default()
         }),
         ..Default::default()
@@ -440,7 +440,7 @@ fn test_get_article_range_multiple_numbers() {
 }
 
 #[test]
-fn test_get_article_range_dash_range() {
+fn test_get_email_range_dash_range() {
     let config = AppConfig {
         nthreads: 1,
         output_dir: "./output".to_string(),
@@ -448,7 +448,7 @@ fn test_get_article_range_dash_range() {
         nntp: Some(NntpConfig {
             hostname: "nntp.example.com".to_string(),
             port: Some(119),
-            article_range: Some("1-5".to_string()),
+            email_range: Some("1-5".to_string()),
             ..NntpConfig::default()
         }),
         ..Default::default()
@@ -463,14 +463,14 @@ fn test_get_article_range_dash_range() {
 }
 
 #[test]
-fn test_get_article_range_mixed() {
+fn test_get_email_range_mixed() {
     let config = AppConfig {
         nthreads: 1,
         output_dir: "./output".to_string(),
         loop_groups: true,
         nntp: Some(NntpConfig {
             hostname: "nntp.example.com".to_string(),
-            article_range: Some("1,3-5,10".to_string()),
+            email_range: Some("1,3-5,10".to_string()),
             ..NntpConfig::default()
         }),
         ..Default::default()
@@ -485,7 +485,7 @@ fn test_get_article_range_mixed() {
 }
 
 #[test]
-fn test_get_article_range_invalid() {
+fn test_get_email_range_invalid() {
     let config = AppConfig {
         nthreads: 1,
         output_dir: "./output".to_string(),
@@ -493,7 +493,7 @@ fn test_get_article_range_invalid() {
         nntp: Some(NntpConfig {
             hostname: "nntp.example.com".to_string(),
             port: Some(119),
-            article_range: Some("invalid".to_string()),
+            email_range: Some("invalid".to_string()),
             ..NntpConfig::default()
         }),
         ..Default::default()
@@ -510,7 +510,7 @@ fn test_get_article_range_invalid() {
 }
 
 #[test]
-fn test_get_article_range_no_nntp() {
+fn test_get_email_range_no_nntp() {
     let config = AppConfig {
         nthreads: 1,
         output_dir: "./output".to_string(),
@@ -539,7 +539,7 @@ read_lists:
 nntp:
   hostname: "nntp.example.com"
   port: 119
-  article_range: "1-10"
+  email_range: "1-10"
 "#;
 
     let mut config: AppConfig = serde_yaml::from_str(yaml).expect("Failed to parse");
@@ -550,7 +550,7 @@ nntp:
     assert!(config.loop_groups);
     assert!(config.nntp.is_some());
 
-    // Verify article range parsing
+    // Verify email range parsing
     let range = config.get_range_selection_text(RunMode::NNTP);
     assert!(range.is_some());
     let range_vec: Vec<usize> = mlh_archiver::range_inputs::parse_sequence(&range.unwrap())

--- a/mlh_archiver/tests/test_nntp.rs
+++ b/mlh_archiver/tests/test_nntp.rs
@@ -329,7 +329,7 @@ fn test_read_single_article_by_range() {
                     hostname: "localhost".to_owned(),
                     port: Some(host_port),
                     request_interval: 0,
-                    article_range: Some("5".to_owned()),
+                    email_range: Some("5".to_owned()),
                     ..NntpConfig::default()
                 }),
                 ..Default::default()
@@ -368,7 +368,7 @@ fn test_read_single_article_by_range() {
 }
 
 #[test]
-fn test_read_article_range() {
+fn test_read_email_range() {
     let found_files = run_nntp_test_with_config(
         |host_port| {
             AppConfig {
@@ -384,7 +384,7 @@ fn test_read_article_range() {
                     hostname: "localhost".to_owned(),
                     port: Some(host_port),
                     request_interval: 0,
-                    article_range: Some("1-3".to_owned()),
+                    email_range: Some("1-3".to_owned()),
                     ..NntpConfig::default()
                 }),
                 ..Default::default()
@@ -444,7 +444,7 @@ fn test_read_multiple_articles_by_range() {
                     hostname: "localhost".to_owned(),
                     port: Some(host_port),
                     request_interval: 0,
-                    article_range: Some("1,5,10".to_owned()),
+                    email_range: Some("1,5,10".to_owned()),
                     ..NntpConfig::default()
                 }),
                 ..Default::default()
@@ -509,7 +509,7 @@ fn test_read_mixed_range() {
                     hostname: "localhost".to_owned(),
                     port: Some(host_port),
                     request_interval: 0,
-                    article_range: Some("1,3-5,10".to_owned()),
+                    email_range: Some("1,3-5,10".to_owned()),
                     ..NntpConfig::default()
                 }),
                 ..Default::default()

--- a/mlh_archiver/tests/test_public_inbox.rs
+++ b/mlh_archiver/tests/test_public_inbox.rs
@@ -381,7 +381,7 @@ fn test_read_from_synthetic_public_inbox() {
                 import_directory: test_data_path.to_owned(),
                 origin: "synthetic".to_owned(),
                 public_inbox_config: None,
-                article_range: None,
+                email_range: None,
             }),
             ..Default::default()
         },
@@ -410,7 +410,7 @@ fn test_read_from_synthetic_public_inbox() {
 }
 
 #[test]
-fn test_pi_article_range() {
+fn test_pi_email_range() {
     let _found_files = run_pi_test_with_config(
         |test_data_path| AppConfig {
             output_dir: "".to_string(),
@@ -420,7 +420,7 @@ fn test_pi_article_range() {
                 import_directory: test_data_path.to_owned(),
                 origin: "synthetic".to_owned(),
                 public_inbox_config: None,
-                article_range: Some("1-3".to_owned()),
+                email_range: Some("1-3".to_owned()),
             }),
             ..Default::default()
         },
@@ -526,7 +526,7 @@ fn test_read_from_demo_public_inbox() {
             import_directory: demo_dir.to_string_lossy().to_string(),
             origin: "demo".to_owned(),
             public_inbox_config: None,
-            article_range: None,
+            email_range: None,
         }),
         ..Default::default()
     };
@@ -624,9 +624,9 @@ fn test_read_from_demo_public_inbox() {
     println!("Test passed for inbox {}", inbox.name);
 }
 
-/// Test article range functionality
+/// Test email range functionality
 #[test]
-fn test_read_article_range_from_demo() {
+fn test_read_email_range_from_demo() {
     let demo_dir = Path::new("../../public-inbox-demo");
     if !demo_dir.exists() {
         println!("Demo directory not found, skipping test");
@@ -662,7 +662,7 @@ fn test_read_article_range_from_demo() {
             import_directory: demo_dir.to_string_lossy().to_string(),
             origin: "demo".to_owned(),
             public_inbox_config: None,
-            article_range: Some("2".to_owned()), // Only article 2
+            email_range: Some("2".to_owned()), // Only article 2
         }),
         ..Default::default()
     };
@@ -762,7 +762,7 @@ fn test_validate_file_structure_using_helpers() {
             import_directory: demo_dir.to_string_lossy().to_string(),
             origin: "demo".to_owned(),
             public_inbox_config: None,
-            article_range: None,
+            email_range: None,
         }),
         ..Default::default()
     };
@@ -811,7 +811,7 @@ fn test_multi_epoch_all_emails() {
                 import_directory: test_data_path.to_owned(),
                 origin: "synthetic".to_owned(),
                 public_inbox_config: None,
-                article_range: None,
+                email_range: None,
             }),
             ..Default::default()
         },
@@ -840,7 +840,7 @@ fn test_multi_epoch_all_emails() {
 }
 
 #[test]
-fn test_multi_epoch_article_range() {
+fn test_multi_epoch_email_range() {
     let _found_files = run_pi_test_with_config(
         |test_data_path| AppConfig {
             output_dir: "".to_string(),
@@ -850,7 +850,7 @@ fn test_multi_epoch_article_range() {
                 import_directory: test_data_path.to_owned(),
                 origin: "synthetic".to_owned(),
                 public_inbox_config: None,
-                article_range: Some("5-8".to_owned()), // All in epoch 1
+                email_range: Some("5-8".to_owned()), // All in epoch 1
             }),
             ..Default::default()
         },
@@ -888,7 +888,7 @@ fn test_multi_epoch_resume() {
                 import_directory: test_data_path.to_owned(),
                 origin: "synthetic".to_owned(),
                 public_inbox_config: None,
-                article_range: Some("1-4".to_owned()), // Only first 4 emails
+                email_range: Some("1-4".to_owned()), // Only first 4 emails
             }),
             ..Default::default()
         },
@@ -906,7 +906,7 @@ fn test_multi_epoch_resume() {
                 import_directory: test_data_path.to_owned(),
                 origin: "synthetic".to_owned(),
                 public_inbox_config: None,
-                article_range: None, // No range - should resume
+                email_range: None, // No range - should resume
             }),
             ..Default::default()
         },
@@ -1130,7 +1130,7 @@ fn run_pi_archiver_once(inbox_dir: &str, output_dir: &str, read_lists: Vec<Strin
             import_directory: abs_inbox.to_string_lossy().to_string(),
             origin: "local-test".to_owned(),
             public_inbox_config: None,
-            article_range: None,
+            email_range: None,
         }),
         ..Default::default()
     };
@@ -1411,7 +1411,7 @@ fn test_broken_alternates_resume() {
     // Epochs 0 and 1 have broken alternates, epoch 2 is clean.
     create_v2_multi_epoch_inbox(base_dir, inbox_name, &[4, 4, 3], &[0, 1]);
 
-    // Phase 1: Process only first 5 emails with article_range
+    // Phase 1: Process only first 5 emails with email_range
     let abs_base = std::fs::canonicalize(base_dir).expect("canonicalize base_dir");
     let abs_output = std::fs::canonicalize(output_dir).unwrap_or_else(|_| {
         std::fs::create_dir_all(output_dir).expect("create output_dir");
@@ -1434,7 +1434,7 @@ fn test_broken_alternates_resume() {
                 import_directory: abs_base.to_string_lossy().to_string(),
                 origin: "local-test".to_owned(),
                 public_inbox_config: None,
-                article_range: Some("1-5".to_owned()),
+                email_range: Some("1-5".to_owned()),
             }),
             ..Default::default()
         };
@@ -1473,7 +1473,7 @@ fn test_broken_alternates_resume() {
                 import_directory: abs_base.to_string_lossy().to_string(),
                 origin: "local-test".to_owned(),
                 public_inbox_config: None,
-                article_range: None,
+                email_range: None,
             }),
             ..Default::default()
         };

--- a/scripts/check_git/src/main.rs
+++ b/scripts/check_git/src/main.rs
@@ -379,13 +379,13 @@ fn generate_config_yaml(inboxes: &[PublicInbox], inbox_dir: &Path) -> anyhow::Re
         .with_default("public-inbox")
         .prompt()?;
 
-    let article_range = Text::new("Article range (optional, e.g., '1-100'):")
+    let email_range = Text::new("Article range (optional, e.g., '1-100'):")
         .with_default("")
         .prompt()?;
-    let article_range_str = if article_range.trim().is_empty() {
+    let email_range_str = if email_range.trim().is_empty() {
         None
     } else {
-        Some(article_range.trim().to_string())
+        Some(email_range.trim().to_string())
     };
 
     let mut yaml = String::new();
@@ -404,8 +404,8 @@ fn generate_config_yaml(inboxes: &[PublicInbox], inbox_dir: &Path) -> anyhow::Re
     for inbox in inboxes {
         yaml.push_str(&format!("    - \"{}\"\n", inbox.name));
     }
-    if let Some(range) = article_range_str {
-        yaml.push_str(&format!("  article_range: \"{}\"\n", range));
+    if let Some(range) = email_range_str {
+        yaml.push_str(&format!("  email_range: \"{}\"\n", range));
     }
 
     println!("\n{}\n", yaml);

--- a/scripts/check_nntp/src/main.rs
+++ b/scripts/check_nntp/src/main.rs
@@ -1,7 +1,7 @@
 //! check_nntp - Interactive NNTP mailing list browser
 //!
 //! This tool allows you to interactively browse available NNTP mailing lists,
-//! preview article ranges, and generate configuration snippets for the MLH Archiver.
+//! preview email ranges, and generate configuration snippets for the MLH Archiver.
 //!
 //! # Usage
 //!
@@ -215,8 +215,8 @@ fn main() -> mlh_archiver::Result<()> {
         selected.clone()
     };
 
-    // Get group info (article ranges)
-    println!("📊 Fetching article ranges...");
+    // Get group info (email ranges)
+    println!("📊 Fetching email ranges...");
     let groups_info = match mlh_archiver::nntp_source::retrieve_groups_info(
         &server.hostname,
         server.port,
@@ -424,7 +424,7 @@ nntp:
 {}
   read_lists:
 {}
-  # article_range: "1-100"  # Optional: fetch specific range
+  # email_range: "1-100"  # Optional: fetch specific range
 "#,
         server.hostname, port_line, lists_yaml
     )


### PR DESCRIPTION
OpenTelemetry gives us tracing information about the runtime of this app in a much more details than logging can.

This is usefull for development, when trying to understand what is the bottleneck of a implementation,
but can also be usefull when running in production.

This was added as an optional feature. It can be accessed by compiling with `cargo build --release  --features=otel `