### PR TITLE
Add list duplication script

### DIFF
--- a/analysis/src/main.py
+++ b/analysis/src/main.py
@@ -6,6 +6,7 @@ from mlh_analysis import patch_missing
 from mlh_analysis import author_distribution
 from mlh_analysis import date_missing
 from mlh_analysis import sql_querier
+from mlh_analysis import duplicate_messages
 from mlh_analysis.inputs import resolve_inputs
 
 import os
@@ -29,6 +30,9 @@ def main():
         "date_missing": lambda: date_missing.main(inputs["dataset"], output_dir),
         # these scripts below will not run by default
         "author_distribution": lambda: author_distribution.main(
+            inputs["dataset"], output_dir
+        ),
+        "duplicate_messages": lambda: duplicate_messages.main(
             inputs["dataset"], output_dir
         ),
         "sql_querier": lambda: sql_querier.main(

--- a/analysis/src/mlh_analysis/__init__.py
+++ b/analysis/src/mlh_analysis/__init__.py
@@ -6,3 +6,4 @@ from . import patch_missing as patch_missing
 from . import date_missing as date_missing
 from . import sql_querier as sql_querier
 from . import author_distribution as author_distribution
+from . import author_distribution as author_distribution

--- a/analysis/src/mlh_analysis/duplicate_messages.py
+++ b/analysis/src/mlh_analysis/duplicate_messages.py
@@ -1,0 +1,29 @@
+import os
+import polars as pl
+
+
+def main(dataset_dir, output_dir):
+    df = pl.scan_parquet(f"{dataset_dir}/**/*.parquet", hive_partitioning=True)
+
+    df = (
+        df.rename({"list": "x_mailing_list"})
+        .group_by(["message-id", "raw_body"])
+        .agg(
+            pl.col("date").min().alias("date"),
+            pl.col("x_mailing_list").count().alias("number_of_replicas"),
+            pl.col("x_mailing_list").alias("lists_present"),
+        )
+        .with_columns(pl.col("lists_present").list.unique().list.sort())
+        .filter(pl.col("number_of_replicas") >= 2)
+        .rename({"message-id": "message_id"})
+        .sort(["number_of_replicas", "date"], descending=[True, False])
+        .collect()
+    )
+
+    dataset_out = os.path.join(output_dir, "dataset")
+    os.makedirs(dataset_out, exist_ok=True)
+
+    df.write_parquet(os.path.join(dataset_out, "duplicate_messages.parquet"))
+    df.with_columns(pl.col("lists_present").list.join(", ")).write_csv(
+        os.path.join(output_dir, "duplicate_messages.csv")
+    )

--- a/analysis/src/mlh_analysis/duplicate_messages.py
+++ b/analysis/src/mlh_analysis/duplicate_messages.py
@@ -10,8 +10,8 @@ def main(dataset_dir, output_dir):
         .group_by(["message-id", "raw_body"])
         .agg(
             pl.col("date").min().alias("date"),
-            pl.col("x_mailing_list").count().alias("number_of_replicas"),
-            pl.col("x_mailing_list").alias("lists_present"),
+            pl.col("list").count().alias("number_of_replicas"),
+            pl.col("list").alias("lists_present"),
         )
         .with_columns(pl.col("lists_present").list.unique().list.sort())
         .filter(pl.col("number_of_replicas") >= 2)


### PR DESCRIPTION
Adds a new analysis script (list_duplications.py) that identifies duplicate emails within mailing lists, grouping by message ID and body hash and returning the earliest date and replica count.